### PR TITLE
Feat/process b

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+dist/
+*.egg-info/
+*.egg
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+.env
+.env.*
+!.env.example
+
+# Test / coverage artifacts
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+.tox/
+.nox/
+
+# Type checker / linter caches
+.mypy_cache/
+.ruff_cache/
+.pyre/
+.pytype/
+
+# SQLite (local outbox during dev)
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+*.sqlite
+*.sqlite3
+
+# IDE / editor
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/process-a/README.md
+++ b/process-a/README.md
@@ -1,0 +1,31 @@
+# Process A — sampler
+
+This directory is **reserved for Process A**, the sampler daemon that reads ADCs / load cells on the Raspberry Pi and emits weight readings as UDP datagrams to Process B.
+
+Process A is owned by a separate teammate. Code will land here once that work begins.
+
+## Contract with Process B
+
+Process A sends one reading per UDP datagram, JSON UTF-8, to Process B's listener port:
+
+```json
+{
+  "shelf_id": "550e8400-e29b-41d4-a716-446655440000",
+  "scale_index": 0,
+  "est_grams": 750.2,
+  "sampled_at": "2026-04-21T08:30:00Z"
+}
+```
+
+Process A also listens on its own control port for `wake` commands from Process B:
+
+```json
+{ "type": "wake" }
+```
+
+Sleep is handled locally by Process A via an inactivity timer; Process B never sends sleep commands.
+
+## See also
+
+- [`../process-b/`](../process-b/) — the broker/persister daemon that consumes these datagrams.
+- [`../README.md`](../README.md) — system overview.

--- a/process-b/README.md
+++ b/process-b/README.md
@@ -118,7 +118,7 @@ JSON UTF-8 to `PROC_A_CONTROL_HOST:PROC_A_CONTROL_PORT`:
 { "type": "wake" }
 ```
 
-Tentative — finalize with Process A's owner. `id` and `expires_at` are not propagated; wake is fire-and-forget over IPC.
+Tentative - finalize with Process A's owner. `id` and `expires_at` are not propagated; wake is fire-and-forget over IPC.
 
 ## Development
 

--- a/process-b/README.md
+++ b/process-b/README.md
@@ -1,0 +1,171 @@
+# ShelfAware — Process B
+
+Process B is the **broker / persister daemon** that runs on a Raspberry Pi as part of the ShelfAware smart-shelf inventory system. It bridges hardware (load-cell readings from Process A) and the network (the Cloudflare Worker backend).
+
+## Where this fits
+
+ShelfAware has three pieces on the Pi and one piece in the cloud:
+
+| Component   | Owner       | Role                                                                  |
+| ----------- | ----------- | --------------------------------------------------------------------- |
+| Process A   | Teammate    | Reads ADCs, emits weight readings as UDP datagrams. Owns sleep/wake.  |
+| **Process B** | **This repo** | UDP listener → SQLite outbox → HTTP client + command poller.          |
+| Backend     | Deployed    | Cloudflare Worker (Hono + TS). `POST /telemetry`, `GET /commands`.    |
+| Frontend    | Teammate    | SvelteKit app reading shelf state from Supabase directly.             |
+
+Process B never computes shelf state — that's the backend's job. Process B's only contracts are: receive UDP, persist, drain, poll for wakes.
+
+## Responsibilities
+
+1. **Listen** for UDP datagrams from Process A on a fixed port. Each datagram is one weight reading.
+2. **Persist** each reading to SQLite (`pending_readings`) immediately. SQLite is a transient outbox — readings buffer there only until the backend accepts them.
+3. **Drain** the outbox every ~5s: claim a batch (≤50 readings, grouped by `shelf_id`), POST to `/telemetry`, `DELETE` on 2xx, bump `reject_count` on rare whole-batch 4xx, retry with exponential backoff (cap 30s) on 5xx / network errors.
+4. **Poll** `GET /commands` every ~3s. Forward any `wake` command to Process A's UDP control port as `{"type": "wake"}`. Drop expired commands.
+
+These are three independent `asyncio` tasks. The UDP listener binds and starts receiving immediately on startup; the drainer and poller run independently.
+
+## Architecture
+
+```
+Process A ──UDP──► udp_listener.py ──► db.insert_reading ──► SQLite (pending_readings)
+                                                                  │
+                                                                  ▼
+                                                          drainer.py ──HTTP──► POST /telemetry
+                                                                                    │
+                                                                          (2xx) DELETE rows
+                                                                          (skipped[]) DELETE + WARN log
+                                                                          (4xx whole batch) bump reject_count
+                                                                          (5xx / network) backoff, retry
+
+                                              poller.py ──HTTP──► GET /commands
+                                                  │
+                                                  └─wake──► ipc.py ──UDP──► Process A control port
+```
+
+## Dependencies
+
+- Python **3.11+**
+- [`httpx`](https://www.python-httpx.org/) (async) — backend HTTP client
+- [`aiosqlite`](https://github.com/omnilib/aiosqlite) — async SQLite
+- [`pydantic`](https://docs.pydantic.dev/) v2 — datagram + payload validation
+
+Dev: `pytest`, `pytest-asyncio`, `respx`, `ruff`, `mypy`.
+
+## Configuration
+
+All config via environment variables. No config files. The daemon is supervised by `systemd` in production.
+
+| Variable                | Required | Default      | Description                                          |
+| ----------------------- | -------- | ------------ | ---------------------------------------------------- |
+| `PI_API_KEY`            | yes      | —            | Bearer token for the backend.                        |
+| `BACKEND_URL`           | yes      | —            | Base URL of the Cloudflare Worker.                   |
+| `DB_PATH`               | yes      | —            | Path to the SQLite file on the Pi.                   |
+| `UDP_LISTEN_HOST`       | no       | `0.0.0.0`    | Bind address for the listener.                       |
+| `UDP_LISTEN_PORT`       | yes      | —            | Port Process A sends readings to.                    |
+| `PROC_A_CONTROL_HOST`   | no       | `127.0.0.1`  | Where Process A listens for control datagrams.       |
+| `PROC_A_CONTROL_PORT`   | yes      | —            | Process A's control port.                            |
+| `DRAIN_INTERVAL_SEC`    | no       | `5`          | Seconds between drain ticks.                         |
+| `DRAIN_BATCH_SIZE`      | no       | `50`         | Max readings per `/telemetry` request.               |
+| `POLL_INTERVAL_SEC`     | no       | `3`          | Seconds between `/commands` polls.                   |
+| `LOG_LEVEL`             | no       | `INFO`       | Stdlib logging level.                                |
+
+## SQLite schema
+
+`db.py` runs this idempotently on startup (`CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`):
+
+```sql
+CREATE TABLE pending_readings (
+  reading_id   TEXT PRIMARY KEY,           -- UUIDv4, generated by Process B at insert time
+  shelf_id     TEXT NOT NULL,              -- UUIDv4
+  scale_index  INTEGER NOT NULL,
+  est_grams    REAL NOT NULL,
+  sampled_at   TEXT NOT NULL,              -- ISO 8601, from Process A
+  metadata     TEXT,                       -- optional JSON: {"battery": 88, "rssi": -65}
+  reject_count INTEGER NOT NULL DEFAULT 0  -- bumped on rare whole-batch 4xx; quarantine after 3
+);
+
+CREATE INDEX idx_pending_readings_shelf_sampled
+  ON pending_readings (shelf_id, sampled_at);
+```
+
+Design notes:
+
+- The table is a **transient outbox**, not an audit log. Drained rows are `DELETE`d.
+- `reject_count` is reserved for whole-batch 4xx (malformed payload, auth failure, etc.). Per-row rejections come back as `200 + skipped[]` and result in a plain `DELETE` plus a `WARN` log — they do **not** bump `reject_count`.
+- 5xx and network errors never bump `reject_count` — they would falsely poison rows during long offline periods.
+- Rows with `reject_count >= 3` are **quarantined**: the drainer skips them (`WHERE reject_count < 3`). They are left in the table for operator inspection.
+
+## UDP datagram format (Process A → Process B)
+
+JSON UTF-8, one reading per datagram:
+
+```json
+{
+  "shelf_id": "550e8400-e29b-41d4-a716-446655440000",
+  "scale_index": 0,
+  "est_grams": 750.2,
+  "sampled_at": "2026-04-21T08:30:00Z"
+}
+```
+
+`metadata` (battery, rssi) is not in the current datagram; the column is wired through end-to-end so Process A can start emitting it without changes here beyond the listener.
+
+## Wake datagram (Process B → Process A)
+
+JSON UTF-8 to `PROC_A_CONTROL_HOST:PROC_A_CONTROL_PORT`:
+
+```json
+{ "type": "wake" }
+```
+
+Tentative — finalize with Process A's owner. `id` and `expires_at` are not propagated; wake is fire-and-forget over IPC.
+
+## Development
+
+All commands below assume the current directory is this one (`process-b/`).
+
+```bash
+python -m venv .venv
+.venv\Scripts\activate                # Windows
+# source .venv/bin/activate           # macOS/Linux
+pip install -e ".[dev]"
+
+pytest
+ruff check .
+ruff format --check .
+mypy
+```
+
+Local development uses mocked I/O (no real Pi, no real Process A). Real-Pi integration happens after the modules are unit-tested.
+
+## Running
+
+For local/manual runs:
+
+```bash
+process-b
+```
+
+Graceful shutdown on `SIGTERM`: stop accepting UDP, drain in-flight HTTP, close the DB.
+
+For Raspberry Pi production deployment as a managed `systemd` service, see [`deploy/README.md`](deploy/README.md).
+
+## Project layout
+
+```
+process_b/
+  main.py              # entrypoint: load config, start tasks, graceful shutdown
+  config.py            # env-var loader
+  db.py                # aiosqlite wrapper (insert, claim, delete, bump)
+  udp_listener.py      # asyncio.DatagramProtocol → db.insert_reading
+  drainer.py           # claim → POST /telemetry → delete or bump
+  poller.py            # GET /commands → ipc.send_wake
+  backend_client.py    # httpx.AsyncClient wrapper
+  ipc.py               # UDP send to Process A
+  logging_setup.py     # JSON formatter for stdlib logging
+tests/
+  test_db.py
+  test_drainer.py
+  test_poller.py
+  test_udp_listener.py
+```

--- a/process-b/deploy/README.md
+++ b/process-b/deploy/README.md
@@ -1,0 +1,334 @@
+# Deploying Process B on a Raspberry Pi
+
+This directory contains the deployment artifacts for running Process B as a managed `systemd` service on the Pi, plus the runbook for getting it there.
+
+| File                        | Purpose                                                   |
+| --------------------------- | --------------------------------------------------------- |
+| `process-b.service`         | systemd unit definition.                                  |
+| `process-b.env.example`     | Template for the environment file (`PI_API_KEY`, etc.).   |
+
+The runbook below assumes the Pi is reached over SSH via [Tailscale](https://tailscale.com). If you're on the same LAN as the Pi, replace `<pi-tailnet-name>` with the Pi's hostname or IP everywhere — every step after SSH is identical.
+
+---
+
+## Prerequisites
+
+### On your laptop
+
+- Tailscale installed and logged into the same tailnet as the Pi.
+- `tailscale status` lists the Pi (e.g. `pi-shelf-1`).
+- An SSH key whose public half is in `~pi/.ssh/authorized_keys` on the Pi.
+
+### On the Pi
+
+- Raspberry Pi OS, recently updated (`sudo apt update && sudo apt full-upgrade -y`).
+- **Python 3.11+** (`python3 --version`). Recent Raspberry Pi OS (Bookworm) ships 3.11; older Bullseye ships 3.9 and won't work without manual install.
+- Tailscale running (`tailscale up` already done) and SSH allowed by your tailnet ACLs.
+- Network reachability to `BACKEND_URL`.
+- Process A running, or able to be started, on the same Pi — Process B is the broker, not the sampler.
+
+Confirm prerequisites before deploying:
+
+```bash
+# From your laptop:
+tailscale status                           # Pi appears in the list
+ssh pi@<pi-tailnet-name>                   # SSH works
+ssh pi@<pi-tailnet-name> python3 --version # 3.11+
+```
+
+If `python3 --version` shows 3.10 or older, fix that first. Everything below assumes 3.11+.
+
+---
+
+## Step-by-step deployment
+
+Every command below runs **on the Pi** unless otherwise noted. SSH in once and stay there.
+
+### Step 1 — Get the code onto the Pi
+
+Two options. Use **A** if the Pi can reach GitHub; use **B** if it can't.
+
+**A. Clone directly (preferred — future updates are `git pull`):**
+
+```bash
+ssh pi@<pi-tailnet-name>
+cd ~
+git clone https://github.com/your-org/ShelfAware-IoT.git
+```
+
+**B. Push from laptop via `scp` (firewall-isolated Pi):**
+
+From your laptop:
+
+```bash
+cd /path/to/ShelfAware-IoT
+git archive --format=tar.gz --output=shelfaware.tar.gz HEAD
+scp shelfaware.tar.gz pi@<pi-tailnet-name>:~/
+```
+
+Then on the Pi:
+
+```bash
+mkdir -p ~/ShelfAware-IoT
+tar -xzf ~/shelfaware.tar.gz -C ~/ShelfAware-IoT
+```
+
+> Tip: long commands (like `pip install`) over Tailscale can drop if your laptop's tailnet connection blips. Run inside `tmux` or `screen` on the Pi for safety: `tmux new -s deploy`, do the work, `Ctrl+B D` to detach, `tmux attach -t deploy` to reattach.
+
+### Step 2 — Create the service user and directories
+
+```bash
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin process-b
+
+sudo install -d -o process-b -g process-b /var/lib/process-b
+sudo install -d -o root -g process-b -m 0750 /etc/process-b
+sudo install -d -o process-b -g process-b /opt/process-b
+```
+
+Verify:
+
+```bash
+id process-b
+ls -ld /var/lib/process-b /etc/process-b /opt/process-b
+```
+
+You should see three directories with the right ownerships, and `/etc/process-b` mode `0750`.
+
+### Step 3 — Install Process B into a venv
+
+```bash
+sudo -u process-b python3 -m venv /opt/process-b/.venv
+sudo -u process-b /opt/process-b/.venv/bin/pip install --upgrade pip
+sudo -u process-b /opt/process-b/.venv/bin/pip install ~/ShelfAware-IoT/process-b
+```
+
+Note the path: we install just the `process-b/` subdirectory of the repo, not the repo root.
+
+Confirm the entrypoint:
+
+```bash
+ls -l /opt/process-b/.venv/bin/process-b
+```
+
+### Step 4 — Install the environment file
+
+```bash
+sudo cp ~/ShelfAware-IoT/process-b/deploy/process-b.env.example /etc/process-b/process-b.env
+sudo nano /etc/process-b/process-b.env
+```
+
+At minimum, fill in the required vars (see the file's comments for the full list):
+
+```
+PI_API_KEY=<bearer token from the backend>
+BACKEND_URL=https://api.shelfaware.example.com
+DB_PATH=/var/lib/process-b/outbox.db
+SHELF_IDS=550e8400-e29b-41d4-a716-446655440000
+UDP_LISTEN_PORT=5005
+PROC_A_CONTROL_PORT=5006
+```
+
+Save, then lock down permissions — `PI_API_KEY` is a secret:
+
+```bash
+sudo chown root:process-b /etc/process-b/process-b.env
+sudo chmod 0640 /etc/process-b/process-b.env
+ls -l /etc/process-b/process-b.env
+```
+
+The `process-b` user can read it; nobody else can.
+
+### Step 5 — Smoke-test by hand (recommended)
+
+Before letting `systemd` manage the daemon, run it once manually so you catch typos in `BACKEND_URL` or a wrong `PI_API_KEY` *before* they show up as a confusing systemd "service kept restarting" loop.
+
+```bash
+sudo -u process-b bash -c '
+  set -a; . /etc/process-b/process-b.env; set +a
+  /opt/process-b/.venv/bin/process-b
+'
+```
+
+What you should see:
+
+- Three startup lines as JSON: `udp listener bound`, `drainer started`, `poller started`.
+- Every 3s, a poll log. If those are `commands GET` succeeding (no commands → no further output), you're healthy.
+
+Press **Ctrl+C** to stop. Then move on.
+
+If you see `permanent failure status=401`, your `PI_API_KEY` is wrong. If `transient failure` with a connect error, your `BACKEND_URL` is wrong or the Pi can't reach the internet.
+
+### Step 6 — Install and enable the systemd unit
+
+```bash
+sudo cp ~/ShelfAware-IoT/process-b/deploy/process-b.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now process-b
+```
+
+`enable --now` enables auto-start at boot *and* starts the daemon immediately.
+
+Check status:
+
+```bash
+sudo systemctl status process-b
+```
+
+Look for `Active: active (running)` and recent JSON log lines. If you see `failed` or constant restarts, see [Troubleshooting](#troubleshooting).
+
+Tail the live logs:
+
+```bash
+sudo journalctl -u process-b -f -o cat
+```
+
+Press Ctrl+C to stop tailing — the daemon keeps running. If you have `jq` installed (`sudo apt install jq`), pipe through it for prettier output:
+
+```bash
+sudo journalctl -u process-b -f -o cat | jq
+```
+
+### Step 7 — End-to-end verification
+
+Once the daemon is up, confirm a real datagram makes it through. From the Pi (or any machine that can reach `127.0.0.1:5005`):
+
+```bash
+echo '{"shelf_id":"550e8400-e29b-41d4-a716-446655440000","scale_index":0,"est_grams":750.2,"sampled_at":"2026-04-21T08:30:00Z"}' \
+  | nc -u -w1 127.0.0.1 5005
+```
+
+Within 5 seconds (one drain tick), `journalctl` should show a `telemetry POST accepted` line. Confirm the row was deleted from the outbox after a successful POST:
+
+```bash
+sudo -u process-b sqlite3 /var/lib/process-b/outbox.db \
+  "SELECT count(*) FROM pending_readings;"
+```
+
+`0` means the drainer successfully POSTed and deleted. If the count is non-zero and stays that way:
+
+- The backend isn't accepting the POST → check the `journalctl` for transient/permanent failure logs.
+- The shelf_id isn't recognized by the backend → backend's `shelf_items` table needs the `scale_index` provisioned.
+
+---
+
+## Tailscale-specific notes
+
+These only matter because you're remote.
+
+- **Don't expose the UDP listener on the tailnet.** `UDP_LISTEN_HOST=0.0.0.0` (the default) binds all interfaces. Process A is local to the Pi, so the listener doesn't need to be reachable from your laptop. For stricter security: set `UDP_LISTEN_HOST=127.0.0.1`. Cost: you can't send test datagrams from your laptop without an SSH tunnel; benefit: one less attack surface.
+
+- **Long commands and tailnet drops.** If your Tailscale connection blips during `pip install`, `tmux` keeps the install running on the Pi. Reattach when the tailnet recovers.
+
+- **`journalctl -f` over SSH.** Works fine; high-latency tailnets show logs in bursts rather than line-by-line. Add `--no-pager` if your terminal does anything weird with the buffer.
+
+- **Updating later** (from your laptop):
+
+  ```bash
+  ssh pi@<pi-tailnet-name>
+  cd ~/ShelfAware-IoT && git pull
+  sudo -u process-b /opt/process-b/.venv/bin/pip install --upgrade ~/ShelfAware-IoT/process-b
+  sudo systemctl restart process-b
+  sudo systemctl status process-b
+  ```
+
+  Pending readings in `/var/lib/process-b/outbox.db` survive across upgrades.
+
+---
+
+## Operating
+
+| Action                          | Command                                |
+| ------------------------------- | -------------------------------------- |
+| Status + last 10 log lines      | `systemctl status process-b`           |
+| Tail logs live                  | `journalctl -u process-b -f`           |
+| Tail with JSON pretty-print     | `journalctl -u process-b -f -o cat \| jq` |
+| Stop                            | `sudo systemctl stop process-b`        |
+| Start                           | `sudo systemctl start process-b`       |
+| Restart (e.g. after env change) | `sudo systemctl restart process-b`     |
+| Disable auto-start at boot      | `sudo systemctl disable process-b`     |
+
+### Adding a shelf
+
+1. Edit `/etc/process-b/process-b.env`. Append the new UUID to `SHELF_IDS` (comma-separated).
+2. `sudo systemctl restart process-b`.
+
+The drainer and listener don't need to be told — they discover `shelf_id` from datagrams. Only the poller needs the configured set.
+
+### Reading the outbox manually
+
+```bash
+sudo -u process-b sqlite3 /var/lib/process-b/outbox.db \
+  "SELECT shelf_id, scale_index, est_grams, sampled_at, reject_count
+   FROM pending_readings
+   ORDER BY sampled_at DESC LIMIT 20;"
+```
+
+Quarantined rows (`reject_count >= 3`) are skipped by the drainer:
+
+```bash
+sudo -u process-b sqlite3 /var/lib/process-b/outbox.db \
+  "SELECT * FROM pending_readings WHERE reject_count >= 3;"
+```
+
+If they're irrecoverable (likely `unknown_scale` config), delete by hand once the underlying issue is fixed:
+
+```bash
+sudo -u process-b sqlite3 /var/lib/process-b/outbox.db \
+  "DELETE FROM pending_readings WHERE reject_count >= 3;"
+```
+
+---
+
+## What "healthy" looks like
+
+On a quiet system (no datagrams arriving, no commands pending), you should see:
+
+- Three startup log lines, then quiet.
+- A `commands GET` log every ~3s (that's the poll cadence; no commands → no further output).
+- No drainer logs unless the listener has inserted a row.
+- Memory under 30 MB; CPU near 0%.
+
+If the daemon is logging anything other than that pattern when nothing is happening, something's wrong — see below.
+
+---
+
+## Troubleshooting
+
+| Symptom                                         | First thing to check                                                                              |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `systemctl status` says `Active: failed`        | `journalctl -u process-b -n 50 -o cat` — last lines tell you why.                                 |
+| Service starts then stops within seconds        | Probably `ConfigError` (missing/typo'd env var). Error goes to stderr → journald.                 |
+| Poller logs `permanent failure status=401`      | `PI_API_KEY` is wrong, or backend doesn't recognize the token.                                    |
+| Poller logs `transient failure` repeatedly      | `BACKEND_URL` is wrong, backend is down, or the Pi has no internet.                               |
+| Listener never inserts rows                     | Process A is sending to a different port. Confirm `UDP_LISTEN_PORT` matches A's config.           |
+| `pending_readings` row count keeps growing      | Backend unreachable (check transient logs) **or** rows quarantined (check `reject_count` column). |
+| `Permission denied` on `outbox.db`              | `ReadWritePaths=` in `process-b.service` doesn't match `DB_PATH`. They must match.                |
+| `process-b` command not found                   | The venv path doesn't match `ExecStart=`. Confirm `/opt/process-b/.venv/bin/process-b` exists.    |
+| `journalctl` shows nothing after start          | `systemd-journald` may have rate-limited. Check `journalctl --vacuum-size=100M` or wait it out.   |
+
+---
+
+## Hardening
+
+The unit file enables a standard set of `systemd` sandbox knobs (`NoNewPrivileges`, `ProtectSystem=strict`, `MemoryDenyWriteExecute`, etc.). The daemon can only:
+
+- Read the world (the venv, the env file).
+- Write to `/var/lib/process-b` (the SQLite outbox).
+- Open AF_INET / AF_INET6 / AF_UNIX sockets.
+
+Everything else is denied. If you ever need to add a writable path, append it to `ReadWritePaths=` in the unit file.
+
+---
+
+## Uninstalling
+
+```bash
+sudo systemctl disable --now process-b
+sudo rm /etc/systemd/system/process-b.service
+sudo systemctl daemon-reload
+
+sudo rm -rf /opt/process-b
+sudo rm -rf /etc/process-b
+# /var/lib/process-b contains the outbox — keep or delete deliberately.
+sudo userdel process-b
+```

--- a/process-b/deploy/process-b.env.example
+++ b/process-b/deploy/process-b.env.example
@@ -1,0 +1,42 @@
+# ShelfAware Process B — environment file template.
+#
+# Install location: /etc/process-b/process-b.env
+# Permissions:      sudo chown root:process-b /etc/process-b/process-b.env
+#                   sudo chmod 0640 /etc/process-b/process-b.env
+#
+# This file is read by systemd via EnvironmentFile= in process-b.service.
+# Keys must be KEY=VALUE with no quoting unless the value itself needs it.
+# Lines beginning with `#` are comments.
+#
+# Schema mirrors process_b/config.py — see ../README.md for the full table.
+
+# --- Required ------------------------------------------------------------
+
+# Bearer token for the Cloudflare Worker backend.
+PI_API_KEY=replace-me-with-real-token
+
+# Base URL of the backend (no trailing slash needed; one will be stripped).
+BACKEND_URL=https://api.shelfaware.example.com
+
+# Where the SQLite outbox lives. Must be in a directory writable by the
+# `process-b` user. The unit file's ReadWritePaths= must include this dir.
+DB_PATH=/var/lib/process-b/outbox.db
+
+# Comma-separated list of shelf UUIDs this Pi services. Single-shelf
+# deployments use one UUID; multi-shelf deployments add more.
+SHELF_IDS=550e8400-e29b-41d4-a716-446655440000
+
+# UDP port Process A sends weight readings to.
+UDP_LISTEN_PORT=5005
+
+# UDP port Process A listens on for wake commands.
+PROC_A_CONTROL_PORT=5006
+
+# --- Optional (defaults applied if unset) --------------------------------
+
+# UDP_LISTEN_HOST=0.0.0.0
+# PROC_A_CONTROL_HOST=127.0.0.1
+# DRAIN_INTERVAL_SEC=5
+# DRAIN_BATCH_SIZE=50
+# POLL_INTERVAL_SEC=3
+# LOG_LEVEL=INFO

--- a/process-b/deploy/process-b.service
+++ b/process-b/deploy/process-b.service
@@ -1,0 +1,54 @@
+[Unit]
+Description=ShelfAware Process B (broker/persister daemon)
+Documentation=https://github.com/your-org/ShelfAware-IoT/tree/main/process-b
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/process-b/.venv/bin/process-b
+Restart=on-failure
+RestartSec=5
+
+# Run as a dedicated unprivileged user. Create with:
+#   sudo useradd --system --no-create-home --shell /usr/sbin/nologin process-b
+User=process-b
+Group=process-b
+
+# Every PI_API_KEY / BACKEND_URL / SHELF_IDS / port / interval lives here.
+# See deploy/process-b.env.example for the schema.
+EnvironmentFile=/etc/process-b/process-b.env
+
+# Send SIGTERM on stop; main.py's signal handler triggers graceful shutdown.
+# 20s is generous — clean shutdown takes under a second in practice, but
+# we want headroom for an in-flight HTTP retry to finish or fail.
+KillSignal=SIGTERM
+TimeoutStopSec=20
+
+# Logs to stdout/stderr → journald. Pair with `journalctl -u process-b`.
+# Our JSON formatter makes `journalctl -u process-b -o cat | jq` queryable.
+StandardOutput=journal
+StandardError=journal
+
+# --- Hardening -----------------------------------------------------------
+# These knobs are "free" defense in depth. If you remove any, document why.
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+
+# The daemon writes to its SQLite outbox here; everything else is read-only.
+# Adjust the path if you change DB_PATH in the environment file.
+ReadWritePaths=/var/lib/process-b
+
+[Install]
+WantedBy=multi-user.target

--- a/process-b/process_b/__init__.py
+++ b/process-b/process_b/__init__.py
@@ -1,0 +1,3 @@
+"""ShelfAware Process B — broker/persister daemon for the Raspberry Pi."""
+
+__version__ = "0.1.0"

--- a/process-b/process_b/backend_client.py
+++ b/process-b/process_b/backend_client.py
@@ -1,0 +1,243 @@
+"""HTTP client for the ShelfAware backend (Cloudflare Worker).
+
+Thin wrapper around :class:`httpx.AsyncClient` that:
+
+- Injects ``Authorization: Bearer <PI_API_KEY>`` and ``X-Shelf-Id`` headers.
+- Validates request/response payloads with pydantic v2 models.
+- Maps HTTP outcomes to two domain exceptions:
+
+  * :class:`TransientBackendError` — 5xx, network errors, timeouts. Caller
+    (the drainer) should back off and retry. Rows are not touched.
+  * :class:`PermanentBackendError` — 4xx and malformed-but-200 responses.
+    Caller should bump ``reject_count`` (drainer) or log + drop (poller).
+
+The client itself does not retry. The drainer owns the retry loop and the
+backoff state; keeping retry policy out of the transport makes both layers
+simpler to reason about and test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from types import TracebackType
+from typing import Self
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+
+class BackendError(Exception):
+    """Base for HTTP-layer failures surfaced to the drainer/poller."""
+
+    def __init__(self, message: str, *, status: int | None = None, body: str | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+class TransientBackendError(BackendError):
+    """5xx, network error, or timeout. Caller should back off and retry."""
+
+
+class PermanentBackendError(BackendError):
+    """4xx or malformed-but-200 response. Caller should not retry."""
+
+
+class ReadingPayload(BaseModel):
+    """One reading as sent on the wire to ``POST /telemetry``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reading_id: str
+    scale_index: int
+    est_grams: float
+
+
+class TelemetryRequest(BaseModel):
+    """Request envelope for ``POST /telemetry``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    shelf_id: str
+    sampled_at: str
+    metadata: dict[str, object] | None = None
+    readings: list[ReadingPayload]
+
+
+class SkippedReading(BaseModel):
+    """One entry of the ``skipped`` array in a 2xx telemetry response."""
+
+    model_config = ConfigDict(extra="allow")
+
+    reading_id: str
+    reason: str
+
+
+class TelemetryResponse(BaseModel):
+    """Parsed 2xx body from ``POST /telemetry``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    accepted: int
+    skipped: list[SkippedReading] = Field(default_factory=list)
+
+
+class Command(BaseModel):
+    """One command from ``GET /commands``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    command: str
+    payload: object | None = None
+    expires_at: str
+
+
+class CommandsResponse(BaseModel):
+    """Parsed 2xx body from ``GET /commands``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    commands: list[Command] = Field(default_factory=list)
+
+
+_DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0)
+
+
+class BackendClient:
+    """Async HTTP client for the ShelfAware Cloudflare Worker.
+
+    Use as an async context manager so the underlying ``httpx.AsyncClient`` is
+    closed on shutdown::
+
+        async with BackendClient(base_url=..., api_key=...) as client:
+            await client.post_telemetry(...)
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        timeout: httpx.Timeout | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = httpx.AsyncClient(
+            timeout=timeout or _DEFAULT_TIMEOUT,
+            headers={"Authorization": f"Bearer {api_key}"},
+            transport=transport,
+        )
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def post_telemetry(
+        self,
+        *,
+        shelf_id: str,
+        sampled_at: str,
+        metadata: dict[str, object] | None,
+        readings: Sequence[ReadingPayload],
+    ) -> TelemetryResponse:
+        """POST a batch of readings for a single shelf. Returns the parsed body.
+
+        Raises
+        ------
+        TransientBackendError
+            5xx, network error, or timeout. Drainer should back off and retry
+            without touching the rows.
+        PermanentBackendError
+            4xx (whole-batch reject — bump ``reject_count``) or
+            malformed-but-200 (treat as 4xx so the row eventually quarantines
+            instead of looping forever).
+        """
+        body = TelemetryRequest(
+            shelf_id=shelf_id,
+            sampled_at=sampled_at,
+            metadata=metadata,
+            readings=list(readings),
+        ).model_dump(mode="json")
+
+        response = await self._request(
+            "POST",
+            "/telemetry",
+            shelf_id=shelf_id,
+            json=body,
+        )
+        return _parse(response, TelemetryResponse)
+
+    async def get_commands(self, *, shelf_id: str) -> list[Command]:
+        """GET pending commands for one shelf. Returns the list (possibly empty).
+
+        Raises the same domain exceptions as :meth:`post_telemetry`.
+        """
+        response = await self._request("GET", "/commands", shelf_id=shelf_id)
+        parsed = _parse(response, CommandsResponse)
+        return parsed.commands
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        shelf_id: str,
+        json: object | None = None,
+    ) -> httpx.Response:
+        """Issue one HTTP request. Maps transport errors to TransientBackendError."""
+        url = f"{self._base_url}{path}"
+        headers = {"X-Shelf-Id": shelf_id}
+        try:
+            return await self._client.request(method, url, headers=headers, json=json)
+        except httpx.TimeoutException as exc:
+            raise TransientBackendError(f"{method} {path}: timeout") from exc
+        except httpx.NetworkError as exc:
+            raise TransientBackendError(f"{method} {path}: network error: {exc}") from exc
+        except httpx.RemoteProtocolError as exc:
+            raise TransientBackendError(f"{method} {path}: protocol error: {exc}") from exc
+
+
+def _parse(response: httpx.Response, model: type[BaseModel]) -> "BaseModel":  # noqa: F821
+    """Map an httpx response to a parsed model or a domain exception.
+
+    - 2xx with a valid body → returns the parsed model.
+    - 2xx with a malformed body → ``PermanentBackendError``. Treating this as
+      transient would loop forever; treating it as permanent at least lets a
+      row quarantine after 3 attempts, which is a finite escape hatch.
+    - 4xx → ``PermanentBackendError``.
+    - 5xx → ``TransientBackendError``.
+    """
+    status = response.status_code
+    text_preview = response.text[:500] if response.text else ""
+
+    if 200 <= status < 300:
+        try:
+            return model.model_validate(response.json())
+        except ValidationError as exc:
+            raise PermanentBackendError(
+                f"malformed response body: {exc}", status=status, body=text_preview
+            ) from exc
+        except ValueError as exc:
+            raise PermanentBackendError(
+                f"non-JSON response body: {exc}", status=status, body=text_preview
+            ) from exc
+
+    if 400 <= status < 500:
+        raise PermanentBackendError(
+            f"backend rejected request: HTTP {status}", status=status, body=text_preview
+        )
+
+    raise TransientBackendError(
+        f"backend transient failure: HTTP {status}", status=status, body=text_preview
+    )

--- a/process-b/process_b/config.py
+++ b/process-b/process_b/config.py
@@ -1,0 +1,149 @@
+"""Environment-variable configuration loader for Process B.
+
+All configuration is read from environment variables — no config files. The
+daemon is supervised by ``systemd`` in production, which provides the env vars
+via the unit file.
+
+The single entry point is :meth:`Config.from_env`, which validates everything
+up front and raises :class:`ConfigError` listing *all* problems at once. This
+makes misconfiguration easy to fix in one shot rather than one var at a time.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+
+class ConfigError(ValueError):
+    """Raised when one or more required env vars are missing or malformed.
+
+    The message lists every problem found, one per line, so the operator can
+    fix all misconfiguration in a single pass.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Resolved configuration for a Process B daemon instance."""
+
+    pi_api_key: str
+    backend_url: str
+    db_path: str
+
+    shelf_ids: tuple[str, ...]
+
+    udp_listen_host: str
+    udp_listen_port: int
+
+    proc_a_control_host: str
+    proc_a_control_port: int
+
+    drain_interval_sec: float
+    drain_batch_size: int
+
+    poll_interval_sec: float
+
+    log_level: str
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> Config:
+        """Build a :class:`Config` from environment variables.
+
+        Parameters
+        ----------
+        env:
+            Optional mapping to read from. Defaults to :data:`os.environ`.
+            Injectable for tests so we never mutate real process env.
+
+        Raises
+        ------
+        ConfigError
+            If any required variable is missing, any integer/float fails to
+            parse, or ``SHELF_IDS`` is empty. All errors collected in one
+            message.
+        """
+        source: Mapping[str, str] = os.environ if env is None else env
+        errors: list[str] = []
+
+        def require(name: str) -> str:
+            value = source.get(name, "").strip()
+            if not value:
+                errors.append(f"{name} is required")
+                return ""
+            return value
+
+        def optional(name: str, default: str) -> str:
+            value = source.get(name)
+            if value is None or value.strip() == "":
+                return default
+            return value.strip()
+
+        def parse_int(name: str, raw: str) -> int:
+            try:
+                return int(raw)
+            except ValueError:
+                errors.append(f"{name} must be an integer, got {raw!r}")
+                return 0
+
+        def parse_float(name: str, raw: str) -> float:
+            try:
+                return float(raw)
+            except ValueError:
+                errors.append(f"{name} must be a number, got {raw!r}")
+                return 0.0
+
+        pi_api_key = require("PI_API_KEY")
+        backend_url = require("BACKEND_URL").rstrip("/")
+        db_path = require("DB_PATH")
+
+        shelf_ids_raw = require("SHELF_IDS")
+        shelf_ids: tuple[str, ...] = ()
+        if shelf_ids_raw:
+            parts = tuple(s.strip() for s in shelf_ids_raw.split(",") if s.strip())
+            if not parts:
+                errors.append("SHELF_IDS must contain at least one shelf UUID")
+            shelf_ids = parts
+
+        udp_listen_host = optional("UDP_LISTEN_HOST", "0.0.0.0")
+        udp_listen_port_raw = require("UDP_LISTEN_PORT")
+        udp_listen_port = parse_int("UDP_LISTEN_PORT", udp_listen_port_raw) if udp_listen_port_raw else 0
+
+        proc_a_control_host = optional("PROC_A_CONTROL_HOST", "127.0.0.1")
+        proc_a_control_port_raw = require("PROC_A_CONTROL_PORT")
+        proc_a_control_port = (
+            parse_int("PROC_A_CONTROL_PORT", proc_a_control_port_raw)
+            if proc_a_control_port_raw
+            else 0
+        )
+
+        drain_interval_sec = parse_float(
+            "DRAIN_INTERVAL_SEC", optional("DRAIN_INTERVAL_SEC", "5")
+        )
+        drain_batch_size = parse_int(
+            "DRAIN_BATCH_SIZE", optional("DRAIN_BATCH_SIZE", "50")
+        )
+        poll_interval_sec = parse_float(
+            "POLL_INTERVAL_SEC", optional("POLL_INTERVAL_SEC", "3")
+        )
+
+        log_level = optional("LOG_LEVEL", "INFO").upper()
+
+        if errors:
+            raise ConfigError("invalid configuration:\n  - " + "\n  - ".join(errors))
+
+        return cls(
+            pi_api_key=pi_api_key,
+            backend_url=backend_url,
+            db_path=db_path,
+            shelf_ids=shelf_ids,
+            udp_listen_host=udp_listen_host,
+            udp_listen_port=udp_listen_port,
+            proc_a_control_host=proc_a_control_host,
+            proc_a_control_port=proc_a_control_port,
+            drain_interval_sec=drain_interval_sec,
+            drain_batch_size=drain_batch_size,
+            poll_interval_sec=poll_interval_sec,
+            log_level=log_level,
+        )

--- a/process-b/process_b/db.py
+++ b/process-b/process_b/db.py
@@ -1,0 +1,230 @@
+"""Async SQLite outbox for Process B.
+
+This module is the single seam through which every other module reads and
+writes ``pending_readings``. The schema is created and maintained by another
+teammate's provisioning script on the Pi; we only *assert* the schema
+(idempotent ``CREATE IF NOT EXISTS``) on startup so local development and
+tests work without that setup step.
+
+Concurrency model
+-----------------
+One daemon process, one writer task (the UDP listener), one reader/deleter
+task (the drainer). No ``SELECT FOR UPDATE``, no row-level locking. "Claim"
+is read-only — rows transition to "drained" only via ``DELETE`` on a
+successful POST, which makes the workflow naturally idempotent on retry.
+
+Boundary types
+--------------
+:class:`Reading` mirrors the on-disk row but exposes ``metadata`` as a parsed
+``dict`` (or ``None``), not the JSON string that lives in the column. The
+JSON encoding/decoding is a storage detail and lives entirely in this
+module; every other layer sees structured values.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import aiosqlite
+
+QUARANTINE_THRESHOLD = 3
+"""Rows with ``reject_count >= QUARANTINE_THRESHOLD`` are skipped by the drainer."""
+
+
+_CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS pending_readings (
+  reading_id   TEXT PRIMARY KEY,
+  shelf_id     TEXT NOT NULL,
+  scale_index  INTEGER NOT NULL,
+  est_grams    REAL NOT NULL,
+  sampled_at   TEXT NOT NULL,
+  metadata     TEXT,
+  reject_count INTEGER NOT NULL DEFAULT 0
+)
+"""
+
+_CREATE_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_pending_readings_shelf_sampled
+  ON pending_readings (shelf_id, sampled_at)
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class Reading:
+    """One row of ``pending_readings``, as returned by :func:`claim_batch`."""
+
+    reading_id: str
+    shelf_id: str
+    scale_index: int
+    est_grams: float
+    sampled_at: str
+    metadata: dict[str, object] | None
+    reject_count: int
+
+
+async def connect(db_path: str) -> aiosqlite.Connection:
+    """Open an aiosqlite connection with sensible PRAGMAs.
+
+    Sets WAL journal mode (concurrent reads while a writer is active) and
+    ``foreign_keys=ON``. Caller owns the connection's lifecycle and must
+    ``await conn.close()`` on shutdown.
+    """
+    conn = await aiosqlite.connect(db_path)
+    await conn.execute("PRAGMA journal_mode=WAL")
+    await conn.execute("PRAGMA foreign_keys=ON")
+    await conn.commit()
+    return conn
+
+
+async def init(conn: aiosqlite.Connection) -> None:
+    """Idempotently assert the ``pending_readings`` schema.
+
+    Runs ``CREATE TABLE IF NOT EXISTS`` and ``CREATE INDEX IF NOT EXISTS``.
+    Safe to call whether the schema was pre-created by the provisioning
+    script or not. We trust the existing schema; we do not verify column
+    names/types — schema drift will surface as an ``OperationalError`` on the
+    first INSERT, which is loud enough.
+    """
+    await conn.execute(_CREATE_TABLE_SQL)
+    await conn.execute(_CREATE_INDEX_SQL)
+    await conn.commit()
+
+
+async def insert_reading(
+    conn: aiosqlite.Connection,
+    *,
+    shelf_id: str,
+    scale_index: int,
+    est_grams: float,
+    sampled_at: str,
+    metadata: dict[str, object] | None,
+) -> str:
+    """Insert one reading. Returns the freshly minted ``reading_id`` (UUIDv4).
+
+    ``metadata``, if provided, is JSON-serialized into the ``metadata``
+    column. Commits before returning so the UDP listener does not need to
+    manage transactions; durability matters more here than throughput
+    (datagrams arrive at human-scale rates).
+    """
+    reading_id = str(uuid.uuid4())
+    metadata_json = json.dumps(metadata, separators=(",", ":")) if metadata is not None else None
+    await conn.execute(
+        """
+        INSERT INTO pending_readings
+            (reading_id, shelf_id, scale_index, est_grams, sampled_at, metadata)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (reading_id, shelf_id, scale_index, est_grams, sampled_at, metadata_json),
+    )
+    await conn.commit()
+    return reading_id
+
+
+async def claim_batch(
+    conn: aiosqlite.Connection,
+    *,
+    batch_size: int,
+) -> list[Reading]:
+    """Return up to ``batch_size`` non-quarantined rows, oldest first per shelf.
+
+    "Claim" is a misnomer kept for readability: there is no row-level lock
+    and no in-flight flag. Rows leave ``pending_readings`` only via
+    :func:`delete_readings`; until then a subsequent ``claim_batch`` will
+    return them again, which is the correct behavior on retry.
+
+    Filters
+    -------
+    ``WHERE reject_count < QUARANTINE_THRESHOLD`` — quarantined rows skipped.
+
+    Order
+    -----
+    ``ORDER BY shelf_id, sampled_at`` — keeps per-shelf time order intact
+    and lets the drainer scan a shelf's rows contiguously when grouping.
+    """
+    if batch_size <= 0:
+        return []
+
+    cursor = await conn.execute(
+        """
+        SELECT reading_id, shelf_id, scale_index, est_grams,
+               sampled_at, metadata, reject_count
+          FROM pending_readings
+         WHERE reject_count < ?
+         ORDER BY shelf_id, sampled_at
+         LIMIT ?
+        """,
+        (QUARANTINE_THRESHOLD, batch_size),
+    )
+    rows = await cursor.fetchall()
+    await cursor.close()
+
+    return [
+        Reading(
+            reading_id=row[0],
+            shelf_id=row[1],
+            scale_index=row[2],
+            est_grams=row[3],
+            sampled_at=row[4],
+            metadata=json.loads(row[5]) if row[5] is not None else None,
+            reject_count=row[6],
+        )
+        for row in rows
+    ]
+
+
+async def delete_readings(
+    conn: aiosqlite.Connection,
+    reading_ids: Iterable[str],
+) -> int:
+    """Delete the named rows. Returns the number of rows actually deleted.
+
+    Empty input is a no-op returning 0. Commits before returning. The drainer
+    calls this on 2xx for both accepted and ``skipped[]`` reading_ids, since
+    both are terminally handled by the backend.
+    """
+    ids = list(reading_ids)
+    if not ids:
+        return 0
+
+    placeholders = ",".join("?" for _ in ids)
+    cursor = await conn.execute(
+        f"DELETE FROM pending_readings WHERE reading_id IN ({placeholders})",
+        ids,
+    )
+    affected = cursor.rowcount
+    await cursor.close()
+    await conn.commit()
+    return affected if affected is not None else 0
+
+
+async def bump_reject_count(
+    conn: aiosqlite.Connection,
+    reading_ids: Iterable[str],
+) -> int:
+    """Increment ``reject_count`` for the named rows. Returns rows affected.
+
+    Reserved for the rare whole-batch 4xx case. Never called on transient
+    failures (5xx, network, timeout) — those would falsely poison rows
+    during long offline periods. Rows that cross ``reject_count >= 3`` are
+    quarantined: :func:`claim_batch` will skip them on subsequent calls.
+    """
+    ids = list(reading_ids)
+    if not ids:
+        return 0
+
+    placeholders = ",".join("?" for _ in ids)
+    cursor = await conn.execute(
+        f"""
+        UPDATE pending_readings
+           SET reject_count = reject_count + 1
+         WHERE reading_id IN ({placeholders})
+        """,
+        ids,
+    )
+    affected = cursor.rowcount
+    await cursor.close()
+    await conn.commit()
+    return affected if affected is not None else 0

--- a/process-b/process_b/drainer.py
+++ b/process-b/process_b/drainer.py
@@ -1,0 +1,267 @@
+"""Outbox drainer: claim → POST /telemetry → delete (or bump, or back off).
+
+The drainer is one of three independent asyncio tasks. It runs a periodic
+loop that:
+
+1. Claims a batch of non-quarantined readings from the SQLite outbox.
+2. Groups them by ``shelf_id`` (one HTTP request per shelf).
+3. POSTs each group to ``/telemetry``.
+
+Per-group outcomes
+------------------
+- **2xx** — Delete every reading in the group, including those returned in
+  ``skipped[]`` (the backend has terminally handled them; they're typically
+  ``unknown_scale`` config-issue rejections, logged at WARN). ``reject_count``
+  is **not** bumped on the skipped path — it's reserved for whole-batch 4xx.
+- **PermanentBackendError (4xx, malformed-200)** — Bump ``reject_count`` for
+  every reading in the group. Three such bumps quarantines a row; the
+  drainer skips quarantined rows on subsequent ticks.
+- **TransientBackendError (5xx, network, timeout)** — Don't touch the rows.
+  They'll be reclaimed on the next tick. The drainer's outer sleep grows
+  exponentially (1s → 2s → 4s → ... cap 30s) until the next *successful*
+  tick, then resets to ``interval``.
+
+Single drainer per process. No cross-task coordination needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+
+import aiosqlite
+
+from process_b import db
+from process_b.backend_client import (
+    BackendClient,
+    PermanentBackendError,
+    ReadingPayload,
+    TransientBackendError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_BACKOFF_INITIAL_SEC = 1.0
+_BACKOFF_CAP_SEC = 30.0
+_BACKOFF_FACTOR = 2.0
+
+
+@dataclass(slots=True)
+class _BackoffState:
+    """Exponential backoff with a cap. Resettable.
+
+    Kept as an explicit object rather than locals so tests can drive it
+    deterministically without mocking time.
+    """
+
+    initial: float = _BACKOFF_INITIAL_SEC
+    cap: float = _BACKOFF_CAP_SEC
+    factor: float = _BACKOFF_FACTOR
+    _current: float = 0.0
+
+    def next_delay(self) -> float:
+        """Return the next backoff delay and advance the state."""
+        if self._current <= 0:
+            self._current = self.initial
+        else:
+            self._current = min(self._current * self.factor, self.cap)
+        return self._current
+
+    def reset(self) -> None:
+        self._current = 0.0
+
+
+async def run_drainer(
+    *,
+    db_conn: aiosqlite.Connection,
+    client: BackendClient,
+    interval: float,
+    batch_size: int,
+    stop_event: asyncio.Event,
+) -> None:
+    """Drain the outbox until ``stop_event`` is set.
+
+    Parameters
+    ----------
+    db_conn:
+        Open aiosqlite connection. Caller owns its lifecycle.
+    client:
+        Open :class:`BackendClient`. Caller owns its lifecycle.
+    interval:
+        Seconds between ticks on the success path. On transient failure the
+        next sleep is taken from ``_BackoffState`` instead, which grows
+        until the next successful (or no-op) tick.
+    batch_size:
+        Maximum number of rows claimed per tick (across all shelves).
+    stop_event:
+        Cleared at startup, set on shutdown. The loop checks it before each
+        sleep and after each wake so shutdown is prompt.
+
+    Errors
+    ------
+    All non-cancellation errors are caught, logged at ERROR, and the loop
+    continues on the next tick. ``asyncio.CancelledError`` propagates so
+    ``TaskGroup`` shutdown semantics work.
+    """
+    backoff = _BackoffState()
+    logger.info(
+        "drainer started",
+        extra={"interval": interval, "batch_size": batch_size},
+    )
+
+    while not stop_event.is_set():
+        had_transient_failure = False
+
+        try:
+            had_transient_failure = await _drain_once(db_conn, client, batch_size)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("drainer tick failed unexpectedly")
+
+        if had_transient_failure:
+            delay = backoff.next_delay()
+            logger.warning(
+                "drainer backing off after transient failure",
+                extra={"delay_sec": delay},
+            )
+        else:
+            backoff.reset()
+            delay = interval
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=delay)
+        except asyncio.TimeoutError:
+            pass
+
+    logger.info("drainer stopped")
+
+
+async def _drain_once(
+    db_conn: aiosqlite.Connection,
+    client: BackendClient,
+    batch_size: int,
+) -> bool:
+    """Run one drain tick. Returns True iff any group hit a transient failure.
+
+    Transient failures elsewhere in the tick do not affect groups that
+    already succeeded — those rows are deleted before the failing group's
+    error propagates to the caller.
+    """
+    batch = await db.claim_batch(db_conn, batch_size=batch_size)
+    if not batch:
+        return False
+
+    grouped: dict[str, list[db.Reading]] = defaultdict(list)
+    for reading in batch:
+        grouped[reading.shelf_id].append(reading)
+
+    transient_seen = False
+    for shelf_id, readings in grouped.items():
+        try:
+            await _post_group(db_conn, client, shelf_id, readings)
+        except TransientBackendError as exc:
+            transient_seen = True
+            logger.warning(
+                "telemetry POST transient failure; rows retained",
+                extra={
+                    "shelf_id": shelf_id,
+                    "count": len(readings),
+                    "status": exc.status,
+                    "error": str(exc),
+                },
+            )
+
+    return transient_seen
+
+
+async def _post_group(
+    db_conn: aiosqlite.Connection,
+    client: BackendClient,
+    shelf_id: str,
+    readings: list[db.Reading],
+) -> None:
+    """POST one shelf's readings and apply the outcome to the DB.
+
+    Per-batch ``sampled_at`` and ``metadata`` come from the most recent
+    reading in the group (by ``sampled_at`` lexicographic order; valid for
+    ISO 8601 UTC strings, which is what the contract requires).
+
+    Raises
+    ------
+    TransientBackendError
+        Re-raised after logging so the caller can mark this tick as a
+        transient failure and apply backoff.
+    """
+    most_recent = max(readings, key=lambda r: r.sampled_at)
+    envelope_metadata = _pick_metadata(readings)
+
+    payload_readings = [
+        ReadingPayload(
+            reading_id=r.reading_id,
+            scale_index=r.scale_index,
+            est_grams=r.est_grams,
+        )
+        for r in readings
+    ]
+
+    try:
+        response = await client.post_telemetry(
+            shelf_id=shelf_id,
+            sampled_at=most_recent.sampled_at,
+            metadata=envelope_metadata,
+            readings=payload_readings,
+        )
+    except PermanentBackendError as exc:
+        logger.error(
+            "telemetry POST permanent failure; bumping reject_count for whole batch",
+            extra={
+                "shelf_id": shelf_id,
+                "count": len(readings),
+                "status": exc.status,
+                "body": exc.body,
+            },
+        )
+        await db.bump_reject_count(db_conn, [r.reading_id for r in readings])
+        return
+
+    skipped_ids = {s.reading_id for s in response.skipped}
+    if skipped_ids:
+        for skipped in response.skipped:
+            logger.warning(
+                "telemetry reading skipped by backend",
+                extra={
+                    "shelf_id": shelf_id,
+                    "reading_id": skipped.reading_id,
+                    "reason": skipped.reason,
+                },
+            )
+
+    all_ids = [r.reading_id for r in readings]
+    deleted = await db.delete_readings(db_conn, all_ids)
+    logger.info(
+        "telemetry POST accepted",
+        extra={
+            "shelf_id": shelf_id,
+            "accepted": response.accepted,
+            "skipped": len(skipped_ids),
+            "deleted": deleted,
+        },
+    )
+
+
+def _pick_metadata(readings: list[db.Reading]) -> dict[str, object] | None:
+    """Pick the most-recent non-null metadata from a shelf's batch.
+
+    Falls back to ``None`` if no reading carries metadata. Ordering by
+    ``sampled_at`` is lexicographic — valid for ISO 8601 UTC strings, which
+    the contract requires.
+    """
+    candidates = [r for r in readings if r.metadata is not None]
+    if not candidates:
+        return None
+    chosen = max(candidates, key=lambda r: r.sampled_at)
+    return chosen.metadata

--- a/process-b/process_b/ipc.py
+++ b/process-b/process_b/ipc.py
@@ -1,0 +1,41 @@
+"""IPC: Process B → Process A control channel.
+
+Process A listens on a UDP control port for wake commands. Process B sends
+``{"type": "wake"}`` as a single JSON UTF-8 datagram. Fire-and-forget: no
+ack, no retry. The backend's command stream is at-most-once by design, so
+one missed wake is an accepted failure mode rather than something to engineer
+around.
+
+The wire payload is tentative — finalize with Process A's owner.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+
+logger = logging.getLogger(__name__)
+
+
+_WAKE_PAYLOAD = json.dumps({"type": "wake"}).encode("utf-8")
+
+
+def send_wake(host: str, port: int) -> None:
+    """Send one wake datagram to ``host:port``. Logs and swallows errors.
+
+    Sync because UDP ``sendto`` is non-blocking and immediate; wrapping in
+    ``asyncio.to_thread`` would add overhead for no benefit. Safe to call
+    from inside an async function.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.sendto(_WAKE_PAYLOAD, (host, port))
+    except OSError as exc:
+        logger.warning(
+            "ipc send_wake failed",
+            extra={"host": host, "port": port, "error": str(exc)},
+        )
+        return
+
+    logger.debug("ipc wake sent", extra={"host": host, "port": port})

--- a/process-b/process_b/logging_setup.py
+++ b/process-b/process_b/logging_setup.py
@@ -1,0 +1,135 @@
+"""Structured-log configuration for Process B.
+
+One JSON-per-line formatter on stdout, ready for ``journald`` ingest. The
+goal is not pretty for humans — ``journalctl -u process-b`` is the human
+interface — but predictable for log shippers, alerting rules, and grep.
+
+Why hand-rolled instead of structlog
+------------------------------------
+We don't yet need cross-task context propagation, log filtering pipelines,
+or pluggable processors. Stdlib ``logging`` plus a 40-line formatter covers
+the use case. If we later want richer structured logging in deep call
+stacks, switching to structlog is a one-day job.
+
+What ends up on each line
+-------------------------
+Always: ``ts`` (UTC ISO-8601 with milliseconds), ``level``, ``logger``,
+``msg``.
+
+Optionally:
+
+- ``task`` — set by a :class:`logging.LoggerAdapter` per asyncio task.
+- ``exc`` — formatted traceback when ``logger.exception(...)`` is used.
+- Anything passed via ``extra={...}`` is merged in at the top level. Reserved
+  field names (``ts``, ``level``, etc.) are not overwritten by ``extra`` —
+  if a caller passes ``extra={"level": "EMERGENCY"}`` we drop it on the
+  floor rather than corrupt the output shape.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+import sys
+from typing import Any
+
+
+_RESERVED_TOP_LEVEL_KEYS: frozenset[str] = frozenset({"ts", "level", "logger", "msg", "exc"})
+
+# Attribute names that ``logging.LogRecord`` sets internally. Anything *not*
+# in this set on a record was passed via ``extra=`` and should be merged
+# into the JSON object.
+_LOGRECORD_BUILTIN_ATTRS: frozenset[str] = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "thread",
+        "threadName",
+        "taskName",  # added in Python 3.12
+    }
+)
+
+
+class JsonFormatter(logging.Formatter):
+    """Render a :class:`logging.LogRecord` as a single JSON object per line."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "ts": _format_ts(record.created),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+
+        for key, value in record.__dict__.items():
+            if key in _LOGRECORD_BUILTIN_ATTRS:
+                continue
+            if key in _RESERVED_TOP_LEVEL_KEYS:
+                continue
+            payload[key] = _coerce(value)
+
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+        elif record.stack_info:
+            payload["exc"] = self.formatStack(record.stack_info)
+
+        return json.dumps(payload, default=_coerce, separators=(",", ":"))
+
+
+def _format_ts(created: float) -> str:
+    """Render a UNIX timestamp as ISO 8601 UTC with milliseconds."""
+    dt = _dt.datetime.fromtimestamp(created, tz=_dt.UTC)
+    base = dt.strftime("%Y-%m-%dT%H:%M:%S")
+    millis = f"{dt.microsecond // 1000:03d}"
+    return f"{base}.{millis}Z"
+
+
+def _coerce(value: Any) -> Any:
+    """Coerce values to something json.dumps can render safely.
+
+    Most things round-trip; a few (like exceptions or arbitrary objects)
+    fall back to ``repr`` rather than raising — a log line is best-effort
+    diagnostic, not durable data.
+    """
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    if isinstance(value, list | tuple):
+        return [_coerce(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _coerce(v) for k, v in value.items()}
+    return repr(value)
+
+
+def configure(level: str = "INFO") -> None:
+    """Install the JSON formatter on the root logger.
+
+    Idempotent: re-running replaces the handler rather than stacking. Safe
+    to call from tests that import :mod:`process_b.main` modules.
+    """
+    root = logging.getLogger()
+    for existing in list(root.handlers):
+        root.removeHandler(existing)
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(JsonFormatter())
+    root.addHandler(handler)
+    root.setLevel(level.upper())

--- a/process-b/process_b/main.py
+++ b/process-b/process_b/main.py
@@ -1,0 +1,157 @@
+"""Process B entrypoint: wire config, DB, HTTP, and the three workers.
+
+Lifecycle
+---------
+1. Load :class:`process_b.config.Config` from the environment.
+2. Configure JSON logging.
+3. Open the SQLite outbox connection and assert the schema.
+4. Open the backend HTTP client.
+5. Start three independent asyncio tasks under one ``TaskGroup``:
+
+   - the UDP listener (binds first so datagrams aren't dropped),
+   - the drainer,
+   - the poller.
+
+6. Install ``SIGTERM`` / ``SIGINT`` handlers (where the platform supports
+   it) that set a shared ``stop_event``.
+7. ``TaskGroup.__aexit__`` waits for all three workers to wind down. Then
+   the HTTP client and DB connection are closed.
+
+The shutdown order matters: workers stop accepting new work *before* the
+DB and HTTP clients close out. ``TaskGroup`` cooperatively coordinates
+this; we don't need explicit barriers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import sys
+from typing import NoReturn
+
+import aiosqlite
+
+from process_b import db, drainer, logging_setup, poller, udp_listener
+from process_b.backend_client import BackendClient
+from process_b.config import Config, ConfigError
+
+logger = logging.getLogger(__name__)
+
+
+def run() -> NoReturn:
+    """Console-script entrypoint declared in ``pyproject.toml``.
+
+    Loads config, configures logging, then hands off to :func:`main`. Exits
+    with code 2 on configuration errors so systemd's ``Restart=on-failure``
+    can distinguish bad config (don't keep restarting) from runtime issues.
+    """
+    try:
+        config = Config.from_env()
+    except ConfigError as exc:
+        # Use stderr directly: logging isn't configured yet.
+        sys.stderr.write(f"{exc}\n")
+        sys.exit(2)
+
+    logging_setup.configure(config.log_level)
+
+    try:
+        asyncio.run(main(config))
+    except KeyboardInterrupt:
+        logger.info("interrupted by user")
+        sys.exit(0)
+    sys.exit(0)
+
+
+async def main(config: Config) -> None:
+    """Open resources, run the three worker tasks, clean up on exit."""
+    stop_event = asyncio.Event()
+    _install_signal_handlers(stop_event)
+
+    db_conn = await db.connect(config.db_path)
+    try:
+        await db.init(db_conn)
+
+        async with BackendClient(
+            base_url=config.backend_url,
+            api_key=config.pi_api_key,
+        ) as client:
+            await _run_workers(config, db_conn, client, stop_event)
+    finally:
+        await db_conn.close()
+        logger.info("process B exited cleanly")
+
+
+async def _run_workers(
+    config: Config,
+    db_conn: aiosqlite.Connection,
+    client: BackendClient,
+    stop_event: asyncio.Event,
+) -> None:
+    """Run the listener, drainer, and poller concurrently until stop_event.
+
+    Bind the UDP listener *first*, before the drainer or poller, so
+    datagrams from Process A are buffered into the outbox even while the
+    network side is still warming up.
+    """
+    listener_protocol = await udp_listener.start_listener(
+        db_conn=db_conn,
+        host=config.udp_listen_host,
+        port=config.udp_listen_port,
+    )
+
+    async def run_listener() -> None:
+        try:
+            await stop_event.wait()
+        finally:
+            await listener_protocol.aclose()
+
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(run_listener(), name="udp_listener")
+        tg.create_task(
+            drainer.run_drainer(
+                db_conn=db_conn,
+                client=client,
+                interval=config.drain_interval_sec,
+                batch_size=config.drain_batch_size,
+                stop_event=stop_event,
+            ),
+            name="drainer",
+        )
+        tg.create_task(
+            poller.run_poller(
+                client=client,
+                shelf_ids=config.shelf_ids,
+                interval=config.poll_interval_sec,
+                ipc_host=config.proc_a_control_host,
+                ipc_port=config.proc_a_control_port,
+                stop_event=stop_event,
+            ),
+            name="poller",
+        )
+
+
+def _install_signal_handlers(stop_event: asyncio.Event) -> None:
+    """Wire SIGTERM/SIGINT to ``stop_event``. Best-effort on Windows.
+
+    ``loop.add_signal_handler`` is Unix-only. On Windows the daemon is
+    expected to be stopped via Ctrl+C, which raises ``KeyboardInterrupt``
+    out of ``asyncio.run`` — handled in :func:`run`.
+    """
+    loop = asyncio.get_running_loop()
+
+    def _handle(signame: str) -> None:
+        logger.info("received signal; shutting down", extra={"signal": signame})
+        stop_event.set()
+
+    if sys.platform == "win32":
+        return
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _handle, sig.name)
+        except NotImplementedError:
+            # Some non-Windows platforms (e.g. inside certain test runners)
+            # also lack add_signal_handler. Fall through silently — Ctrl+C
+            # still works via KeyboardInterrupt.
+            pass

--- a/process-b/process_b/poller.py
+++ b/process-b/process_b/poller.py
@@ -1,0 +1,214 @@
+"""Command poller: backend → Process B → Process A.
+
+Polls ``GET /commands`` for each configured shelf and forwards live ``wake``
+commands to Process A via :mod:`ipc`. One of three independent asyncio
+tasks; runs until ``stop_event`` is set.
+
+No backoff state
+----------------
+Unlike the drainer, the poller has no retry loop and no exponential backoff.
+The poller's contract is *at-most-once* delivery on a fixed cadence: if
+``/commands`` is unreachable for a tick, we miss whatever wakes were live
+during that window, and the next successful poll picks up whatever is still
+pending. Adding backoff would *delay* recovery, which is the opposite of
+what we want.
+
+Per-shelf isolation
+-------------------
+A failure polling shelf A in a tick must not prevent us from polling shelf
+B in the same tick. Each shelf gets its own try/except inside the loop body.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
+
+from process_b.backend_client import (
+    BackendClient,
+    Command,
+    PermanentBackendError,
+    TransientBackendError,
+)
+from process_b.ipc import send_wake as default_send_wake
+
+logger = logging.getLogger(__name__)
+
+
+SendWakeFn = Callable[[str, int], None]
+"""Type alias for the wake-sender. Production uses :func:`process_b.ipc.send_wake`;
+tests inject a fake to assert calls without needing a real UDP listener."""
+
+
+async def run_poller(
+    *,
+    client: BackendClient,
+    shelf_ids: Sequence[str],
+    interval: float,
+    ipc_host: str,
+    ipc_port: int,
+    stop_event: asyncio.Event,
+    send_wake: SendWakeFn = default_send_wake,
+    now_fn: Callable[[], datetime] | None = None,
+) -> None:
+    """Poll the backend until ``stop_event`` is set.
+
+    Parameters
+    ----------
+    client:
+        Open :class:`BackendClient`. Caller owns its lifecycle.
+    shelf_ids:
+        Configured set of shelves served by this Pi (from
+        ``cfg.shelf_ids``). The poller is the only place this set matters;
+        the listener and drainer derive ``shelf_id`` from data, not config.
+    interval:
+        Seconds between ticks. The current sleep is interruptible via
+        ``stop_event`` so shutdown is prompt.
+    ipc_host, ipc_port:
+        Process A's control endpoint. Closed-over so the per-tick code path
+        is a single positional call to ``send_wake``.
+    stop_event:
+        Cleared at startup, set on shutdown.
+    send_wake:
+        Injectable wake-sender. Production path is the module-level
+        :func:`process_b.ipc.send_wake`; tests substitute a recorder.
+    now_fn:
+        Injectable clock. Defaults to ``datetime.now(UTC)``. Tests use a
+        fixed clock to make ``expires_at`` checks deterministic.
+
+    Errors
+    ------
+    Per-shelf errors are logged and the loop continues. ``CancelledError``
+    propagates so ``TaskGroup`` shutdown semantics work.
+    """
+    clock = now_fn or (lambda: datetime.now(UTC))
+
+    if not shelf_ids:
+        logger.warning("poller starting with no configured shelves; loop will idle")
+
+    logger.info(
+        "poller started",
+        extra={"interval": interval, "shelves": list(shelf_ids)},
+    )
+
+    while not stop_event.is_set():
+        try:
+            await _poll_once(client, shelf_ids, ipc_host, ipc_port, send_wake, clock)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("poller tick failed unexpectedly")
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+        except asyncio.TimeoutError:
+            pass
+
+    logger.info("poller stopped")
+
+
+async def _poll_once(
+    client: BackendClient,
+    shelf_ids: Sequence[str],
+    ipc_host: str,
+    ipc_port: int,
+    send_wake: SendWakeFn,
+    clock: Callable[[], datetime],
+) -> None:
+    """One tick: poll every shelf in turn, forwarding live wakes."""
+    for shelf_id in shelf_ids:
+        try:
+            commands = await client.get_commands(shelf_id=shelf_id)
+        except TransientBackendError as exc:
+            logger.warning(
+                "commands GET transient failure",
+                extra={"shelf_id": shelf_id, "status": exc.status, "error": str(exc)},
+            )
+            continue
+        except PermanentBackendError as exc:
+            logger.error(
+                "commands GET permanent failure",
+                extra={"shelf_id": shelf_id, "status": exc.status, "body": exc.body},
+            )
+            continue
+
+        for cmd in commands:
+            _handle_command(cmd, shelf_id, ipc_host, ipc_port, send_wake, clock)
+
+
+def _handle_command(
+    cmd: Command,
+    shelf_id: str,
+    ipc_host: str,
+    ipc_port: int,
+    send_wake: SendWakeFn,
+    clock: Callable[[], datetime],
+) -> None:
+    """Decide what to do with one command. Wake commands are forwarded;
+    everything else is logged and dropped.
+    """
+    if cmd.command != "wake":
+        logger.info(
+            "unsupported command type; ignored",
+            extra={"shelf_id": shelf_id, "command_id": cmd.id, "command": cmd.command},
+        )
+        return
+
+    if _is_expired(cmd.expires_at, clock):
+        logger.info(
+            "expired wake command; dropped",
+            extra={
+                "shelf_id": shelf_id,
+                "command_id": cmd.id,
+                "expires_at": cmd.expires_at,
+            },
+        )
+        return
+
+    logger.info(
+        "forwarding wake to process A",
+        extra={
+            "shelf_id": shelf_id,
+            "command_id": cmd.id,
+            "ipc_host": ipc_host,
+            "ipc_port": ipc_port,
+        },
+    )
+    send_wake(ipc_host, ipc_port)
+
+
+def _is_expired(expires_at: str, clock: Callable[[], datetime]) -> bool:
+    """Return True iff ``expires_at`` is at or before "now" in UTC.
+
+    The backend pre-filters expired commands per the contract, so this is
+    defense in depth. If the timestamp is unparseable we treat the command
+    as live — better to err toward forwarding than to silently drop on a
+    backend bug we don't understand yet. The forwarded wake is still safe
+    because Process A treats wakes idempotently.
+    """
+    try:
+        ts = _parse_iso8601(expires_at)
+    except ValueError:
+        logger.warning(
+            "could not parse expires_at; treating as live",
+            extra={"expires_at": expires_at},
+        )
+        return False
+
+    return ts <= clock()
+
+
+def _parse_iso8601(value: str) -> datetime:
+    """Parse an ISO 8601 string into a timezone-aware UTC ``datetime``.
+
+    Handles ``Z`` suffix (Python's ``fromisoformat`` accepts it natively
+    only from 3.11+, which we require). Naive datetimes are assumed UTC —
+    the contract requires UTC; a naive timestamp from the backend would be
+    a bug, but treating it as UTC is the least-surprising recovery.
+    """
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed

--- a/process-b/process_b/udp_listener.py
+++ b/process-b/process_b/udp_listener.py
@@ -1,0 +1,221 @@
+"""UDP listener: Process A → SQLite outbox.
+
+One ``asyncio.DatagramProtocol`` per listener. Each datagram is a JSON UTF-8
+encoded :class:`IncomingReading`. On valid input, schedule an
+``insert_reading`` task and return immediately so the event loop can keep
+servicing the socket. On invalid input, log at WARN and drop the datagram —
+the listener never crashes on bad data.
+
+Why ``create_task`` instead of awaiting
+---------------------------------------
+``DatagramProtocol.datagram_received`` is a sync callback. Doing real work
+inline would block the event loop and risk dropped datagrams (UDP gives no
+backpressure). Spawning a task lets the loop return to the socket
+immediately.
+
+Tasks are tracked in a set with a ``done_callback`` so they're not
+garbage-collected mid-flight (CPython's documented gotcha for
+``asyncio.create_task``).
+
+The listener's two contracts
+----------------------------
+- :func:`start_listener` opens the socket and returns the transport plus a
+  way to stop. ``main.py`` calls it during boot, before the drainer/poller,
+  so datagrams are buffered into the outbox even while the network side is
+  warming up.
+- The :class:`TelemetryProtocol` class is exposed for tests, which inject
+  raw bytes via ``datagram_received`` without binding a real socket.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+from typing import cast
+
+import aiosqlite
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from process_b import db
+
+logger = logging.getLogger(__name__)
+
+
+class IncomingReading(BaseModel):
+    """Wire-format datagram from Process A.
+
+    JSON UTF-8::
+
+        {
+          "shelf_id": "<UUIDv4>",
+          "scale_index": <int >= 0>,
+          "est_grams": <finite float>,
+          "sampled_at": "<ISO 8601 UTC string>"
+        }
+
+    ``sampled_at`` is kept as a string — the contract specifies ISO 8601
+    UTC, and Process B forwards it verbatim to the backend. Round-tripping
+    through a ``datetime`` would risk timezone-stripping bugs.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    shelf_id: str = Field(min_length=1)
+    scale_index: int = Field(ge=0)
+    est_grams: float
+    sampled_at: str = Field(min_length=1)
+
+    @field_validator("est_grams")
+    @classmethod
+    def _est_grams_must_be_finite(cls, v: float) -> float:
+        if not math.isfinite(v):
+            raise ValueError("est_grams must be finite (no NaN, no infinity)")
+        return v
+
+
+class TelemetryProtocol(asyncio.DatagramProtocol):
+    """Receives one datagram at a time and persists it asynchronously.
+
+    Exposed for tests. Production code uses :func:`start_listener`, which
+    binds a real socket and returns the underlying transport.
+    """
+
+    def __init__(self, db_conn: aiosqlite.Connection) -> None:
+        self._db = db_conn
+        self._tasks: set[asyncio.Task[object]] = set()
+        self._transport: asyncio.DatagramTransport | None = None
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        self._transport = cast("asyncio.DatagramTransport", transport)
+        sock = transport.get_extra_info("sockname")
+        logger.info("udp listener bound", extra={"sockname": sock})
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        try:
+            reading = _parse_datagram(data)
+        except _DatagramError as exc:
+            logger.warning(
+                "udp datagram dropped",
+                extra={
+                    "addr": addr,
+                    "reason": exc.reason,
+                    "size": len(data),
+                },
+            )
+            return
+
+        task = asyncio.create_task(self._persist(reading, addr))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    def error_received(self, exc: Exception) -> None:
+        logger.warning("udp listener error_received", extra={"error": str(exc)})
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        if exc is not None:
+            logger.warning("udp listener connection_lost", extra={"error": str(exc)})
+        else:
+            logger.info("udp listener connection_lost")
+
+    async def aclose(self) -> None:
+        """Stop accepting datagrams and wait for in-flight inserts to finish.
+
+        Called on shutdown by ``main.py``. Closing the transport first
+        guarantees no new ``datagram_received`` callbacks fire; awaiting
+        in-flight tasks guarantees no row is dropped.
+        """
+        if self._transport is not None:
+            self._transport.close()
+            self._transport = None
+
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+
+    async def _persist(self, reading: IncomingReading, addr: tuple[str, int]) -> None:
+        """Insert one validated reading. Errors are logged, never raised.
+
+        Raising out of a background task would only be visible at task GC
+        time and would not crash the listener — but we'd lose the row's
+        context. Logging here keeps the diagnostic close to the cause.
+        """
+        try:
+            reading_id = await db.insert_reading(
+                self._db,
+                shelf_id=reading.shelf_id,
+                scale_index=reading.scale_index,
+                est_grams=reading.est_grams,
+                sampled_at=reading.sampled_at,
+                metadata=None,
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                "failed to persist incoming reading",
+                extra={
+                    "addr": addr,
+                    "shelf_id": reading.shelf_id,
+                    "scale_index": reading.scale_index,
+                },
+            )
+            return
+
+        logger.debug(
+            "udp reading persisted",
+            extra={
+                "addr": addr,
+                "reading_id": reading_id,
+                "shelf_id": reading.shelf_id,
+                "scale_index": reading.scale_index,
+            },
+        )
+
+
+class _DatagramError(Exception):
+    """Internal: parse/validate failure with a short reason string for logs."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _parse_datagram(data: bytes) -> IncomingReading:
+    """Decode UTF-8 + JSON + pydantic. Raises :class:`_DatagramError` on any failure."""
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise _DatagramError(f"invalid utf-8: {exc.reason}") from exc
+
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise _DatagramError(f"invalid json: {exc.msg}") from exc
+
+    if not isinstance(obj, dict):
+        raise _DatagramError("json root is not an object")
+
+    try:
+        return IncomingReading.model_validate(obj)
+    except ValidationError as exc:
+        raise _DatagramError(f"schema mismatch: {exc.errors(include_url=False)}") from exc
+
+
+async def start_listener(
+    *,
+    db_conn: aiosqlite.Connection,
+    host: str,
+    port: int,
+) -> TelemetryProtocol:
+    """Bind the listener and return the protocol instance.
+
+    ``main.py`` keeps the returned protocol so it can call ``aclose()`` on
+    shutdown. The listener starts receiving datagrams as soon as this
+    coroutine returns.
+    """
+    loop = asyncio.get_running_loop()
+    protocol = TelemetryProtocol(db_conn)
+    await loop.create_datagram_endpoint(
+        lambda: protocol,
+        local_addr=(host, port),
+    )
+    return protocol

--- a/process-b/pyproject.toml
+++ b/process-b/pyproject.toml
@@ -1,0 +1,70 @@
+[project]
+name = "process-b"
+version = "0.1.0"
+description = "ShelfAware Process B — UDP listener, SQLite outbox, telemetry drainer, and command poller daemon for the Raspberry Pi."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "ShelfAware" }]
+
+dependencies = [
+    "httpx>=0.27,<1.0",
+    "aiosqlite>=0.20,<1.0",
+    "pydantic>=2.7,<3.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.2",
+    "pytest-asyncio>=0.23",
+    "respx>=0.21",
+    "ruff>=0.6",
+    "mypy>=1.11",
+]
+
+[project.scripts]
+process-b = "process_b.main:run"
+
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["process_b"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-ra"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "UP",  # pyupgrade
+    "SIM", # flake8-simplify
+    "RUF",
+]
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.mypy]
+python_version = "3.11"
+disallow_untyped_defs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_return_any = true
+no_implicit_optional = true
+files = ["process_b", "tests"]
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false

--- a/process-b/tests/test_backend_client.py
+++ b/process-b/tests/test_backend_client.py
@@ -1,0 +1,293 @@
+"""Tests for :mod:`process_b.backend_client`.
+
+Uses ``respx`` to mock httpx at the transport layer. We never hit a real
+network. Each test instantiates its own client; the ``async with`` form makes
+shutdown order obvious.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from process_b.backend_client import (
+    BackendClient,
+    Command,
+    PermanentBackendError,
+    ReadingPayload,
+    TransientBackendError,
+)
+
+
+BASE_URL = "https://api.example.com"
+API_KEY = "secret-pi-key"
+SHELF_A = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _client() -> BackendClient:
+    return BackendClient(base_url=BASE_URL, api_key=API_KEY)
+
+
+def _readings(n: int = 1) -> list[ReadingPayload]:
+    return [
+        ReadingPayload(reading_id=f"00000000-0000-4000-8000-00000000000{i}", scale_index=i, est_grams=100.0 + i)
+        for i in range(n)
+    ]
+
+
+class TestPostTelemetry:
+    @respx.mock
+    async def test_2xx_returns_parsed_response(self) -> None:
+        route = respx.post(f"{BASE_URL}/telemetry").mock(
+            return_value=httpx.Response(200, json={"accepted": 2, "skipped": []})
+        )
+
+        async with _client() as client:
+            result = await client.post_telemetry(
+                shelf_id=SHELF_A,
+                sampled_at="2026-04-21T08:30:00Z",
+                metadata={"battery": 88},
+                readings=_readings(2),
+            )
+
+        assert result.accepted == 2
+        assert result.skipped == []
+        assert route.called
+
+    @respx.mock
+    async def test_sends_required_headers_and_body(self) -> None:
+        route = respx.post(f"{BASE_URL}/telemetry").mock(
+            return_value=httpx.Response(200, json={"accepted": 1, "skipped": []})
+        )
+
+        async with _client() as client:
+            await client.post_telemetry(
+                shelf_id=SHELF_A,
+                sampled_at="2026-04-21T08:30:00Z",
+                metadata=None,
+                readings=_readings(1),
+            )
+
+        request = route.calls.last.request
+        assert request.headers["Authorization"] == f"Bearer {API_KEY}"
+        assert request.headers["X-Shelf-Id"] == SHELF_A
+
+        import json as _json
+
+        body = _json.loads(request.content)
+        assert body["shelf_id"] == SHELF_A
+        assert body["sampled_at"] == "2026-04-21T08:30:00Z"
+        assert body["metadata"] is None
+        assert len(body["readings"]) == 1
+        assert body["readings"][0]["scale_index"] == 0
+
+    @respx.mock
+    async def test_2xx_with_skipped_entries_parses(self) -> None:
+        respx.post(f"{BASE_URL}/telemetry").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "accepted": 1,
+                    "skipped": [
+                        {"reading_id": "abc", "reason": "unknown_scale"},
+                        {"reading_id": "def", "reason": "future_unknown_reason"},
+                    ],
+                },
+            )
+        )
+
+        async with _client() as client:
+            result = await client.post_telemetry(
+                shelf_id=SHELF_A,
+                sampled_at="2026-04-21T08:30:00Z",
+                metadata=None,
+                readings=_readings(3),
+            )
+
+        assert result.accepted == 1
+        assert [s.reading_id for s in result.skipped] == ["abc", "def"]
+        assert result.skipped[0].reason == "unknown_scale"
+
+    @respx.mock
+    async def test_4xx_raises_permanent_error(self) -> None:
+        respx.post(f"{BASE_URL}/telemetry").mock(
+            return_value=httpx.Response(400, text="bad request body")
+        )
+
+        async with _client() as client:
+            with pytest.raises(PermanentBackendError) as exc:
+                await client.post_telemetry(
+                    shelf_id=SHELF_A,
+                    sampled_at="2026-04-21T08:30:00Z",
+                    metadata=None,
+                    readings=_readings(1),
+                )
+
+        assert exc.value.status == 400
+        assert "bad request body" in (exc.value.body or "")
+
+    @respx.mock
+    async def test_5xx_raises_transient_error(self) -> None:
+        respx.post(f"{BASE_URL}/telemetry").mock(
+            return_value=httpx.Response(503, text="upstream down")
+        )
+
+        async with _client() as client:
+            with pytest.raises(TransientBackendError) as exc:
+                await client.post_telemetry(
+                    shelf_id=SHELF_A,
+                    sampled_at="2026-04-21T08:30:00Z",
+                    metadata=None,
+                    readings=_readings(1),
+                )
+
+        assert exc.value.status == 503
+
+    @respx.mock
+    async def test_network_error_is_transient(self) -> None:
+        respx.post(f"{BASE_URL}/telemetry").mock(side_effect=httpx.ConnectError("refused"))
+
+        async with _client() as client:
+            with pytest.raises(TransientBackendError) as exc:
+                await client.post_telemetry(
+                    shelf_id=SHELF_A,
+                    sampled_at="2026-04-21T08:30:00Z",
+                    metadata=None,
+                    readings=_readings(1),
+                )
+
+        assert exc.value.status is None
+        assert "network" in str(exc.value).lower()
+
+    @respx.mock
+    async def test_timeout_is_transient(self) -> None:
+        respx.post(f"{BASE_URL}/telemetry").mock(side_effect=httpx.ReadTimeout("slow"))
+
+        async with _client() as client:
+            with pytest.raises(TransientBackendError) as exc:
+                await client.post_telemetry(
+                    shelf_id=SHELF_A,
+                    sampled_at="2026-04-21T08:30:00Z",
+                    metadata=None,
+                    readings=_readings(1),
+                )
+
+        assert exc.value.status is None
+        assert "timeout" in str(exc.value).lower()
+
+    @respx.mock
+    async def test_2xx_malformed_body_is_permanent(self) -> None:
+        respx.post(f"{BASE_URL}/telemetry").mock(
+            return_value=httpx.Response(200, json={"unexpected": "shape"})
+        )
+
+        async with _client() as client:
+            with pytest.raises(PermanentBackendError):
+                await client.post_telemetry(
+                    shelf_id=SHELF_A,
+                    sampled_at="2026-04-21T08:30:00Z",
+                    metadata=None,
+                    readings=_readings(1),
+                )
+
+    @respx.mock
+    async def test_2xx_non_json_body_is_permanent(self) -> None:
+        respx.post(f"{BASE_URL}/telemetry").mock(
+            return_value=httpx.Response(200, text="not json at all")
+        )
+
+        async with _client() as client:
+            with pytest.raises(PermanentBackendError):
+                await client.post_telemetry(
+                    shelf_id=SHELF_A,
+                    sampled_at="2026-04-21T08:30:00Z",
+                    metadata=None,
+                    readings=_readings(1),
+                )
+
+
+class TestGetCommands:
+    @respx.mock
+    async def test_returns_empty_list_when_no_commands(self) -> None:
+        respx.get(f"{BASE_URL}/commands").mock(
+            return_value=httpx.Response(200, json={"commands": []})
+        )
+
+        async with _client() as client:
+            result = await client.get_commands(shelf_id=SHELF_A)
+
+        assert result == []
+
+    @respx.mock
+    async def test_parses_wake_command(self) -> None:
+        respx.get(f"{BASE_URL}/commands").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "commands": [
+                        {
+                            "id": "cmd-1",
+                            "command": "wake",
+                            "payload": None,
+                            "expires_at": "2026-04-21T08:35:00Z",
+                        }
+                    ]
+                },
+            )
+        )
+
+        async with _client() as client:
+            result = await client.get_commands(shelf_id=SHELF_A)
+
+        assert len(result) == 1
+        cmd = result[0]
+        assert isinstance(cmd, Command)
+        assert cmd.id == "cmd-1"
+        assert cmd.command == "wake"
+        assert cmd.expires_at == "2026-04-21T08:35:00Z"
+
+    @respx.mock
+    async def test_sends_required_headers(self) -> None:
+        route = respx.get(f"{BASE_URL}/commands").mock(
+            return_value=httpx.Response(200, json={"commands": []})
+        )
+
+        async with _client() as client:
+            await client.get_commands(shelf_id=SHELF_A)
+
+        request = route.calls.last.request
+        assert request.headers["Authorization"] == f"Bearer {API_KEY}"
+        assert request.headers["X-Shelf-Id"] == SHELF_A
+
+    @respx.mock
+    async def test_5xx_raises_transient_error(self) -> None:
+        respx.get(f"{BASE_URL}/commands").mock(return_value=httpx.Response(502))
+
+        async with _client() as client:
+            with pytest.raises(TransientBackendError):
+                await client.get_commands(shelf_id=SHELF_A)
+
+    @respx.mock
+    async def test_4xx_raises_permanent_error(self) -> None:
+        respx.get(f"{BASE_URL}/commands").mock(return_value=httpx.Response(401, text="bad token"))
+
+        async with _client() as client:
+            with pytest.raises(PermanentBackendError) as exc:
+                await client.get_commands(shelf_id=SHELF_A)
+
+        assert exc.value.status == 401
+
+
+class TestLifecycle:
+    async def test_aclose_closes_underlying_client(self) -> None:
+        client = _client()
+        assert not client._client.is_closed  # type: ignore[reportPrivateUsage]
+        await client.aclose()
+        assert client._client.is_closed  # type: ignore[reportPrivateUsage]
+
+    async def test_context_manager_closes_on_exit(self) -> None:
+        async with _client() as client:
+            inner = client._client  # type: ignore[reportPrivateUsage]
+            assert not inner.is_closed
+        assert inner.is_closed

--- a/process-b/tests/test_config.py
+++ b/process-b/tests/test_config.py
@@ -1,0 +1,120 @@
+"""Tests for :mod:`process_b.config`.
+
+These are pure-function tests over a synthetic env mapping. We never touch
+``os.environ`` so the suite is order-independent and parallel-safe.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from process_b.config import Config, ConfigError
+
+
+SHELF_A = "550e8400-e29b-41d4-a716-446655440000"
+SHELF_B = "660e8400-e29b-41d4-a716-446655440001"
+
+
+def _minimal_env(**overrides: str) -> dict[str, str]:
+    """Return a valid env mapping; tests override individual keys."""
+    env = {
+        "PI_API_KEY": "secret",
+        "BACKEND_URL": "https://api.example.com/",
+        "DB_PATH": "/var/lib/process-b/outbox.db",
+        "SHELF_IDS": SHELF_A,
+        "UDP_LISTEN_PORT": "5005",
+        "PROC_A_CONTROL_PORT": "5006",
+    }
+    env.update(overrides)
+    return env
+
+
+class TestHappyPath:
+    def test_minimal_required_env_yields_defaults_for_optionals(self) -> None:
+        cfg = Config.from_env(_minimal_env())
+
+        assert cfg.pi_api_key == "secret"
+        assert cfg.backend_url == "https://api.example.com"  # trailing slash stripped
+        assert cfg.db_path == "/var/lib/process-b/outbox.db"
+        assert cfg.shelf_ids == (SHELF_A,)
+
+        assert cfg.udp_listen_host == "0.0.0.0"
+        assert cfg.udp_listen_port == 5005
+        assert cfg.proc_a_control_host == "127.0.0.1"
+        assert cfg.proc_a_control_port == 5006
+
+        assert cfg.drain_interval_sec == pytest.approx(5.0)
+        assert cfg.drain_batch_size == 50
+        assert cfg.poll_interval_sec == pytest.approx(3.0)
+
+        assert cfg.log_level == "INFO"
+
+    def test_optionals_when_provided_override_defaults(self) -> None:
+        cfg = Config.from_env(
+            _minimal_env(
+                UDP_LISTEN_HOST="127.0.0.1",
+                PROC_A_CONTROL_HOST="10.0.0.5",
+                DRAIN_INTERVAL_SEC="2.5",
+                DRAIN_BATCH_SIZE="100",
+                POLL_INTERVAL_SEC="1",
+                LOG_LEVEL="debug",
+            )
+        )
+
+        assert cfg.udp_listen_host == "127.0.0.1"
+        assert cfg.proc_a_control_host == "10.0.0.5"
+        assert cfg.drain_interval_sec == pytest.approx(2.5)
+        assert cfg.drain_batch_size == 100
+        assert cfg.poll_interval_sec == pytest.approx(1.0)
+        assert cfg.log_level == "DEBUG"
+
+    def test_shelf_ids_parses_comma_separated_list(self) -> None:
+        cfg = Config.from_env(_minimal_env(SHELF_IDS=f"{SHELF_A}, {SHELF_B} ,"))
+        assert cfg.shelf_ids == (SHELF_A, SHELF_B)
+
+    def test_config_is_frozen(self) -> None:
+        cfg = Config.from_env(_minimal_env())
+        with pytest.raises((AttributeError, Exception)):
+            cfg.pi_api_key = "other"  # type: ignore[misc]
+
+
+class TestErrors:
+    def test_single_missing_required_var_is_named(self) -> None:
+        env = _minimal_env()
+        del env["PI_API_KEY"]
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(env)
+        assert "PI_API_KEY" in str(exc.value)
+
+    def test_blank_required_var_is_treated_as_missing(self) -> None:
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(_minimal_env(PI_API_KEY="   "))
+        assert "PI_API_KEY" in str(exc.value)
+
+    def test_multiple_missing_vars_all_reported_in_one_error(self) -> None:
+        env = _minimal_env()
+        del env["PI_API_KEY"]
+        del env["BACKEND_URL"]
+        del env["UDP_LISTEN_PORT"]
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(env)
+        msg = str(exc.value)
+        assert "PI_API_KEY" in msg
+        assert "BACKEND_URL" in msg
+        assert "UDP_LISTEN_PORT" in msg
+
+    def test_non_integer_port_is_rejected(self) -> None:
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(_minimal_env(UDP_LISTEN_PORT="not-a-number"))
+        assert "UDP_LISTEN_PORT" in str(exc.value)
+        assert "integer" in str(exc.value)
+
+    def test_non_numeric_drain_interval_is_rejected(self) -> None:
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(_minimal_env(DRAIN_INTERVAL_SEC="soon"))
+        assert "DRAIN_INTERVAL_SEC" in str(exc.value)
+
+    def test_empty_shelf_ids_is_rejected(self) -> None:
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(_minimal_env(SHELF_IDS=" , , "))
+        assert "SHELF_IDS" in str(exc.value)

--- a/process-b/tests/test_db.py
+++ b/process-b/tests/test_db.py
@@ -1,0 +1,311 @@
+"""Tests for :mod:`process_b.db`.
+
+These tests run against a real ``aiosqlite`` connection backed by ``:memory:``
+— it's fast, hermetic, and exercises the actual SQL we ship. Mocking sqlite
+itself would just test our mocks.
+
+Each test gets its own connection via the ``db_conn`` fixture; nothing is
+shared, so order is irrelevant.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from process_b import db
+
+
+SHELF_A = "550e8400-e29b-41d4-a716-446655440000"
+SHELF_B = "660e8400-e29b-41d4-a716-446655440001"
+
+
+@pytest_asyncio.fixture
+async def db_conn() -> AsyncIterator[aiosqlite.Connection]:
+    """Yield an initialized in-memory connection. Closed at teardown."""
+    conn = await aiosqlite.connect(":memory:")
+    await db.init(conn)
+    try:
+        yield conn
+    finally:
+        await conn.close()
+
+
+async def _insert(
+    conn: aiosqlite.Connection,
+    shelf_id: str,
+    scale_index: int,
+    sampled_at: str,
+    *,
+    est_grams: float = 100.0,
+    metadata: dict[str, object] | None = None,
+) -> str:
+    """Test helper: insert and return reading_id."""
+    return await db.insert_reading(
+        conn,
+        shelf_id=shelf_id,
+        scale_index=scale_index,
+        est_grams=est_grams,
+        sampled_at=sampled_at,
+        metadata=metadata,
+    )
+
+
+class TestInit:
+    async def test_creates_table_and_index(self, db_conn: aiosqlite.Connection) -> None:
+        cursor = await db_conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='pending_readings'"
+        )
+        assert await cursor.fetchone() is not None
+        await cursor.close()
+
+        cursor = await db_conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND name='idx_pending_readings_shelf_sampled'"
+        )
+        assert await cursor.fetchone() is not None
+        await cursor.close()
+
+    async def test_init_is_idempotent(self, db_conn: aiosqlite.Connection) -> None:
+        await db.init(db_conn)
+        await db.init(db_conn)
+
+        reading_id = await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+        assert reading_id
+
+
+class TestInsertReading:
+    async def test_returns_uuid_v4_string(self, db_conn: aiosqlite.Connection) -> None:
+        reading_id = await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+
+        import uuid as _uuid
+
+        parsed = _uuid.UUID(reading_id)
+        assert parsed.version == 4
+
+    async def test_persists_all_fields(self, db_conn: aiosqlite.Connection) -> None:
+        reading_id = await _insert(
+            db_conn,
+            SHELF_A,
+            scale_index=2,
+            sampled_at="2026-04-21T08:30:00Z",
+            est_grams=750.2,
+            metadata={"battery": 88, "rssi": -65},
+        )
+
+        cursor = await db_conn.execute(
+            "SELECT shelf_id, scale_index, est_grams, sampled_at, metadata, reject_count "
+            "FROM pending_readings WHERE reading_id = ?",
+            (reading_id,),
+        )
+        row = await cursor.fetchone()
+        await cursor.close()
+
+        assert row is not None
+        assert row[0] == SHELF_A
+        assert row[1] == 2
+        assert row[2] == pytest.approx(750.2)
+        assert row[3] == "2026-04-21T08:30:00Z"
+        assert row[4] is not None and "battery" in row[4]  # JSON-encoded
+        assert row[5] == 0  # reject_count default
+
+    async def test_metadata_none_is_stored_as_null(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        reading_id = await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z", metadata=None)
+
+        cursor = await db_conn.execute(
+            "SELECT metadata FROM pending_readings WHERE reading_id = ?", (reading_id,)
+        )
+        row = await cursor.fetchone()
+        await cursor.close()
+
+        assert row is not None
+        assert row[0] is None
+
+    async def test_each_call_yields_unique_id(self, db_conn: aiosqlite.Connection) -> None:
+        ids = {await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z") for _ in range(5)}
+        assert len(ids) == 5
+
+
+class TestClaimBatch:
+    async def test_returns_empty_when_outbox_empty(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        assert await db.claim_batch(db_conn, batch_size=10) == []
+
+    async def test_zero_or_negative_batch_size_returns_empty(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+        assert await db.claim_batch(db_conn, batch_size=0) == []
+        assert await db.claim_batch(db_conn, batch_size=-1) == []
+
+    async def test_respects_batch_size(self, db_conn: aiosqlite.Connection) -> None:
+        for i in range(5):
+            await _insert(db_conn, SHELF_A, i, f"2026-04-21T08:30:0{i}Z")
+
+        batch = await db.claim_batch(db_conn, batch_size=3)
+        assert len(batch) == 3
+
+    async def test_orders_by_shelf_id_then_sampled_at(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        await _insert(db_conn, SHELF_B, 0, "2026-04-21T08:30:00Z")
+        await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:02Z")
+        await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:01Z")
+        await _insert(db_conn, SHELF_B, 0, "2026-04-21T08:29:00Z")
+
+        batch = await db.claim_batch(db_conn, batch_size=10)
+        ordering = [(r.shelf_id, r.sampled_at) for r in batch]
+        assert ordering == [
+            (SHELF_A, "2026-04-21T08:30:01Z"),
+            (SHELF_A, "2026-04-21T08:30:02Z"),
+            (SHELF_B, "2026-04-21T08:29:00Z"),
+            (SHELF_B, "2026-04-21T08:30:00Z"),
+        ]
+
+    async def test_skips_quarantined_rows(self, db_conn: aiosqlite.Connection) -> None:
+        rid_active = await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+        rid_quarantined = await _insert(db_conn, SHELF_A, 1, "2026-04-21T08:30:01Z")
+
+        await db_conn.execute(
+            "UPDATE pending_readings SET reject_count = ? WHERE reading_id = ?",
+            (db.QUARANTINE_THRESHOLD, rid_quarantined),
+        )
+        await db_conn.commit()
+
+        batch = await db.claim_batch(db_conn, batch_size=10)
+        assert [r.reading_id for r in batch] == [rid_active]
+
+    async def test_metadata_round_trip(self, db_conn: aiosqlite.Connection) -> None:
+        await _insert(
+            db_conn,
+            SHELF_A,
+            0,
+            "2026-04-21T08:30:00Z",
+            metadata={"battery": 88, "rssi": -65},
+        )
+        await _insert(db_conn, SHELF_A, 1, "2026-04-21T08:30:01Z", metadata=None)
+
+        batch = await db.claim_batch(db_conn, batch_size=10)
+        assert batch[0].metadata == {"battery": 88, "rssi": -65}
+        assert batch[1].metadata is None
+
+    async def test_returned_reading_has_all_fields(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        rid = await _insert(
+            db_conn,
+            SHELF_A,
+            scale_index=3,
+            sampled_at="2026-04-21T08:30:00Z",
+            est_grams=420.5,
+            metadata={"battery": 50},
+        )
+
+        (reading,) = await db.claim_batch(db_conn, batch_size=10)
+        assert reading.reading_id == rid
+        assert reading.shelf_id == SHELF_A
+        assert reading.scale_index == 3
+        assert reading.est_grams == pytest.approx(420.5)
+        assert reading.sampled_at == "2026-04-21T08:30:00Z"
+        assert reading.metadata == {"battery": 50}
+        assert reading.reject_count == 0
+
+
+class TestDeleteReadings:
+    async def test_empty_input_is_noop(self, db_conn: aiosqlite.Connection) -> None:
+        assert await db.delete_readings(db_conn, []) == 0
+
+    async def test_deletes_only_named_rows(self, db_conn: aiosqlite.Connection) -> None:
+        rid_a = await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+        rid_b = await _insert(db_conn, SHELF_A, 1, "2026-04-21T08:30:01Z")
+        rid_c = await _insert(db_conn, SHELF_A, 2, "2026-04-21T08:30:02Z")
+
+        deleted = await db.delete_readings(db_conn, [rid_a, rid_c])
+        assert deleted == 2
+
+        remaining = await db.claim_batch(db_conn, batch_size=10)
+        assert [r.reading_id for r in remaining] == [rid_b]
+
+    async def test_unknown_ids_silently_skip(self, db_conn: aiosqlite.Connection) -> None:
+        rid = await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+
+        deleted = await db.delete_readings(db_conn, [rid, "nope-not-a-real-id"])
+        assert deleted == 1
+
+    async def test_accepts_generator(self, db_conn: aiosqlite.Connection) -> None:
+        rid_a = await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+        rid_b = await _insert(db_conn, SHELF_A, 1, "2026-04-21T08:30:01Z")
+
+        deleted = await db.delete_readings(db_conn, (r for r in [rid_a, rid_b]))
+        assert deleted == 2
+
+
+class TestBumpRejectCount:
+    async def test_empty_input_is_noop(self, db_conn: aiosqlite.Connection) -> None:
+        assert await db.bump_reject_count(db_conn, []) == 0
+
+    async def test_bumps_only_named_rows(self, db_conn: aiosqlite.Connection) -> None:
+        rid_a = await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+        rid_b = await _insert(db_conn, SHELF_A, 1, "2026-04-21T08:30:01Z")
+
+        affected = await db.bump_reject_count(db_conn, [rid_a])
+        assert affected == 1
+
+        batch = await db.claim_batch(db_conn, batch_size=10)
+        by_id = {r.reading_id: r.reject_count for r in batch}
+        assert by_id[rid_a] == 1
+        assert by_id[rid_b] == 0
+
+    async def test_three_bumps_quarantine_a_row(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        rid = await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+
+        for _ in range(db.QUARANTINE_THRESHOLD):
+            await db.bump_reject_count(db_conn, [rid])
+
+        assert await db.claim_batch(db_conn, batch_size=10) == []
+
+    async def test_unknown_ids_affect_zero_rows(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        affected = await db.bump_reject_count(db_conn, ["does-not-exist"])
+        assert affected == 0
+
+
+class TestConnect:
+    async def test_connect_then_init_then_use(self, tmp_path) -> None:  # noqa: ANN001
+        db_path = str(tmp_path / "outbox.db")
+        conn = await db.connect(db_path)
+        try:
+            await db.init(conn)
+            rid = await db.insert_reading(
+                conn,
+                shelf_id=SHELF_A,
+                scale_index=0,
+                est_grams=42.0,
+                sampled_at="2026-04-21T08:30:00Z",
+                metadata=None,
+            )
+            (reading,) = await db.claim_batch(conn, batch_size=10)
+            assert reading.reading_id == rid
+        finally:
+            await conn.close()
+
+    async def test_connect_sets_wal_journal_mode(self, tmp_path) -> None:  # noqa: ANN001
+        db_path = str(tmp_path / "outbox.db")
+        conn = await db.connect(db_path)
+        try:
+            cursor = await conn.execute("PRAGMA journal_mode")
+            row = await cursor.fetchone()
+            await cursor.close()
+            assert row is not None
+            assert row[0].lower() == "wal"
+        finally:
+            await conn.close()

--- a/process-b/tests/test_drainer.py
+++ b/process-b/tests/test_drainer.py
@@ -1,0 +1,451 @@
+"""Tests for :mod:`process_b.drainer`.
+
+Strategy
+--------
+- Real aiosqlite ``:memory:`` DB (we already trust :mod:`db`; mocking it
+  would mean writing a fake that's strictly worse than the real thing).
+- Mocked :class:`BackendClient` via a small fake. We're testing the
+  drainer's *decisions*, not httpx; mocking the client surface keeps each
+  test focused on one branch of the state machine.
+- The main loop is exercised end-to-end against the fake client + a
+  ``stop_event`` we set after a controlled number of ticks. We don't test
+  real wall-clock timing — backoff math is unit-tested separately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from process_b import db
+from process_b.backend_client import (
+    PermanentBackendError,
+    SkippedReading,
+    TelemetryResponse,
+    TransientBackendError,
+)
+from process_b.drainer import _BackoffState, _drain_once, _pick_metadata, run_drainer
+
+
+SHELF_A = "550e8400-e29b-41d4-a716-446655440000"
+SHELF_B = "660e8400-e29b-41d4-a716-446655440001"
+
+
+@dataclass
+class _RecordedPost:
+    shelf_id: str
+    sampled_at: str
+    metadata: dict[str, object] | None
+    reading_ids: list[str]
+
+
+@dataclass
+class FakeBackendClient:
+    """Stand-in for :class:`BackendClient` with programmable responses.
+
+    Each call to :meth:`post_telemetry` consumes one entry from
+    ``responses``. Entries are either:
+
+    - a :class:`TelemetryResponse` — returned to the caller.
+    - a :class:`BackendError` subclass — raised.
+
+    Empty queue defaults to ``TelemetryResponse(accepted=N, skipped=[])``,
+    where N is the size of the request being served. Lets simple tests
+    omit setup entirely.
+    """
+
+    responses: list[object] = field(default_factory=list)
+    posts: list[_RecordedPost] = field(default_factory=list)
+    get_commands_responses: list[object] = field(default_factory=list)
+
+    async def post_telemetry(
+        self,
+        *,
+        shelf_id: str,
+        sampled_at: str,
+        metadata: dict[str, object] | None,
+        readings: list,  # noqa: ANN001 — pydantic models, type checked at use site
+    ) -> TelemetryResponse:
+        self.posts.append(
+            _RecordedPost(
+                shelf_id=shelf_id,
+                sampled_at=sampled_at,
+                metadata=metadata,
+                reading_ids=[r.reading_id for r in readings],
+            )
+        )
+        if not self.responses:
+            return TelemetryResponse(accepted=len(readings), skipped=[])
+        outcome = self.responses.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        assert isinstance(outcome, TelemetryResponse)
+        return outcome
+
+
+@pytest_asyncio.fixture
+async def db_conn() -> AsyncIterator[aiosqlite.Connection]:
+    conn = await aiosqlite.connect(":memory:")
+    await db.init(conn)
+    try:
+        yield conn
+    finally:
+        await conn.close()
+
+
+async def _insert(
+    conn: aiosqlite.Connection,
+    shelf_id: str,
+    scale_index: int,
+    sampled_at: str,
+    *,
+    est_grams: float = 100.0,
+    metadata: dict[str, object] | None = None,
+) -> str:
+    return await db.insert_reading(
+        conn,
+        shelf_id=shelf_id,
+        scale_index=scale_index,
+        est_grams=est_grams,
+        sampled_at=sampled_at,
+        metadata=metadata,
+    )
+
+
+async def _outbox(conn: aiosqlite.Connection) -> list[db.Reading]:
+    return await db.claim_batch(conn, batch_size=1000)
+
+
+class TestPickMetadata:
+    def test_returns_none_when_all_metadata_are_none(self) -> None:
+        readings = [
+            db.Reading(
+                reading_id=f"r{i}",
+                shelf_id=SHELF_A,
+                scale_index=i,
+                est_grams=10.0,
+                sampled_at=f"2026-04-21T08:30:0{i}Z",
+                metadata=None,
+                reject_count=0,
+            )
+            for i in range(3)
+        ]
+        assert _pick_metadata(readings) is None
+
+    def test_picks_most_recent_non_null_metadata(self) -> None:
+        readings = [
+            db.Reading(
+                reading_id="r0",
+                shelf_id=SHELF_A,
+                scale_index=0,
+                est_grams=10.0,
+                sampled_at="2026-04-21T08:30:00Z",
+                metadata={"battery": 90},
+                reject_count=0,
+            ),
+            db.Reading(
+                reading_id="r1",
+                shelf_id=SHELF_A,
+                scale_index=1,
+                est_grams=10.0,
+                sampled_at="2026-04-21T08:30:05Z",
+                metadata=None,  # newer in time but null — must not be chosen
+                reject_count=0,
+            ),
+            db.Reading(
+                reading_id="r2",
+                shelf_id=SHELF_A,
+                scale_index=2,
+                est_grams=10.0,
+                sampled_at="2026-04-21T08:30:02Z",
+                metadata={"battery": 88},
+                reject_count=0,
+            ),
+        ]
+        assert _pick_metadata(readings) == {"battery": 88}
+
+
+class TestBackoffState:
+    def test_starts_at_initial_then_doubles(self) -> None:
+        bo = _BackoffState(initial=1.0, cap=30.0, factor=2.0)
+        assert bo.next_delay() == 1.0
+        assert bo.next_delay() == 2.0
+        assert bo.next_delay() == 4.0
+
+    def test_caps_at_max(self) -> None:
+        bo = _BackoffState(initial=1.0, cap=30.0, factor=2.0)
+        for _ in range(20):
+            bo.next_delay()
+        assert bo.next_delay() == 30.0
+
+    def test_reset_returns_to_initial(self) -> None:
+        bo = _BackoffState(initial=1.0, cap=30.0, factor=2.0)
+        bo.next_delay()
+        bo.next_delay()
+        bo.reset()
+        assert bo.next_delay() == 1.0
+
+
+class TestDrainOnce:
+    async def test_empty_outbox_is_noop(self, db_conn: aiosqlite.Connection) -> None:
+        client = FakeBackendClient()
+        had_transient = await _drain_once(db_conn, client, batch_size=50)  # type: ignore[arg-type]
+        assert had_transient is False
+        assert client.posts == []
+
+    async def test_2xx_deletes_all_rows_in_batch(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        for i in range(3):
+            await _insert(db_conn, SHELF_A, i, f"2026-04-21T08:30:0{i}Z")
+
+        client = FakeBackendClient()
+        await _drain_once(db_conn, client, batch_size=50)  # type: ignore[arg-type]
+
+        assert len(client.posts) == 1
+        assert await _outbox(db_conn) == []
+
+    async def test_2xx_with_skipped_still_deletes_skipped_rows(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        rids = [
+            await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z"),
+            await _insert(db_conn, SHELF_A, 1, "2026-04-21T08:30:01Z"),
+        ]
+
+        client = FakeBackendClient(
+            responses=[
+                TelemetryResponse(
+                    accepted=1,
+                    skipped=[SkippedReading(reading_id=rids[1], reason="unknown_scale")],
+                )
+            ]
+        )
+        await _drain_once(db_conn, client, batch_size=50)  # type: ignore[arg-type]
+
+        assert await _outbox(db_conn) == []
+
+    async def test_4xx_bumps_reject_count_for_whole_batch_no_delete(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        rids = [
+            await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z"),
+            await _insert(db_conn, SHELF_A, 1, "2026-04-21T08:30:01Z"),
+        ]
+
+        client = FakeBackendClient(
+            responses=[PermanentBackendError("boom", status=400, body="bad payload")]
+        )
+        had_transient = await _drain_once(db_conn, client, batch_size=50)  # type: ignore[arg-type]
+
+        assert had_transient is False  # 4xx is not transient
+
+        rows = await _outbox(db_conn)
+        assert {r.reading_id for r in rows} == set(rids)
+        assert all(r.reject_count == 1 for r in rows)
+
+    async def test_5xx_does_not_touch_rows_and_signals_transient(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        rids = [
+            await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z"),
+            await _insert(db_conn, SHELF_A, 1, "2026-04-21T08:30:01Z"),
+        ]
+
+        client = FakeBackendClient(
+            responses=[TransientBackendError("upstream down", status=503)]
+        )
+        had_transient = await _drain_once(db_conn, client, batch_size=50)  # type: ignore[arg-type]
+
+        assert had_transient is True
+
+        rows = await _outbox(db_conn)
+        assert {r.reading_id for r in rows} == set(rids)
+        assert all(r.reject_count == 0 for r in rows)
+
+    async def test_groups_by_shelf_one_request_per_shelf(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+        await _insert(db_conn, SHELF_A, 1, "2026-04-21T08:30:01Z")
+        await _insert(db_conn, SHELF_B, 0, "2026-04-21T08:29:00Z")
+
+        client = FakeBackendClient()
+        await _drain_once(db_conn, client, batch_size=50)  # type: ignore[arg-type]
+
+        assert len(client.posts) == 2
+        by_shelf = {p.shelf_id: p for p in client.posts}
+        assert sorted(by_shelf.keys()) == sorted([SHELF_A, SHELF_B])
+        assert len(by_shelf[SHELF_A].reading_ids) == 2
+        assert len(by_shelf[SHELF_B].reading_ids) == 1
+
+    async def test_envelope_uses_most_recent_sampled_at_per_group(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+        await _insert(db_conn, SHELF_A, 1, "2026-04-21T08:30:05Z")
+        await _insert(db_conn, SHELF_A, 2, "2026-04-21T08:30:02Z")
+
+        client = FakeBackendClient()
+        await _drain_once(db_conn, client, batch_size=50)  # type: ignore[arg-type]
+
+        assert client.posts[0].sampled_at == "2026-04-21T08:30:05Z"
+
+    async def test_envelope_metadata_is_most_recent_non_null(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        await _insert(
+            db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z", metadata={"battery": 90}
+        )
+        await _insert(db_conn, SHELF_A, 1, "2026-04-21T08:30:05Z", metadata=None)
+        await _insert(
+            db_conn, SHELF_A, 2, "2026-04-21T08:30:03Z", metadata={"battery": 88}
+        )
+
+        client = FakeBackendClient()
+        await _drain_once(db_conn, client, batch_size=50)  # type: ignore[arg-type]
+
+        assert client.posts[0].metadata == {"battery": 88}
+
+    async def test_one_shelf_5xx_does_not_block_other_shelf_2xx(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        rid_a = await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+        rid_b = await _insert(db_conn, SHELF_B, 0, "2026-04-21T08:30:00Z")
+
+        client = FakeBackendClient(
+            responses=[
+                TransientBackendError("down", status=503),
+                TelemetryResponse(accepted=1, skipped=[]),
+            ]
+        )
+        had_transient = await _drain_once(db_conn, client, batch_size=50)  # type: ignore[arg-type]
+
+        assert had_transient is True
+
+        remaining = await _outbox(db_conn)
+        remaining_ids = {r.reading_id for r in remaining}
+        # Whichever shelf got the 5xx stays; the other was deleted. We can't
+        # rely on dict ordering for which shelf hits 5xx first, so just
+        # assert exactly one row remains and it's one of the originals.
+        assert len(remaining) == 1
+        assert remaining_ids.issubset({rid_a, rid_b})
+
+    async def test_quarantined_rows_are_skipped(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        rid_q = await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+        rid_ok = await _insert(db_conn, SHELF_A, 1, "2026-04-21T08:30:01Z")
+
+        await db_conn.execute(
+            "UPDATE pending_readings SET reject_count = ? WHERE reading_id = ?",
+            (db.QUARANTINE_THRESHOLD, rid_q),
+        )
+        await db_conn.commit()
+
+        client = FakeBackendClient()
+        await _drain_once(db_conn, client, batch_size=50)  # type: ignore[arg-type]
+
+        assert len(client.posts) == 1
+        assert client.posts[0].reading_ids == [rid_ok]
+
+        # The quarantined row is still there; the OK row was deleted.
+        remaining = await db_conn.execute_fetchall(
+            "SELECT reading_id FROM pending_readings"
+        )
+        assert {r[0] for r in remaining} == {rid_q}
+
+
+class TestRunDrainerLoop:
+    async def test_stop_event_terminates_loop(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        client = FakeBackendClient()
+        stop = asyncio.Event()
+        stop.set()  # already set — loop should exit on first check
+
+        await asyncio.wait_for(
+            run_drainer(
+                db_conn=db_conn,
+                client=client,  # type: ignore[arg-type]
+                interval=0.01,
+                batch_size=50,
+                stop_event=stop,
+            ),
+            timeout=1.0,
+        )
+        assert client.posts == []
+
+    async def test_loop_drains_then_exits_on_stop(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        rid = await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+
+        client = FakeBackendClient()
+        stop = asyncio.Event()
+
+        async def stopper() -> None:
+            # Give the drainer one tick to do its work, then signal stop.
+            await asyncio.sleep(0.05)
+            stop.set()
+
+        await asyncio.gather(
+            run_drainer(
+                db_conn=db_conn,
+                client=client,  # type: ignore[arg-type]
+                interval=0.01,
+                batch_size=50,
+                stop_event=stop,
+            ),
+            stopper(),
+        )
+
+        assert any(p.reading_ids == [rid] for p in client.posts)
+        assert await _outbox(db_conn) == []
+
+    async def test_loop_survives_unexpected_db_failure(
+        self, db_conn: aiosqlite.Connection, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If something blows up unexpectedly, the loop logs and keeps going.
+
+        We patch ``db.claim_batch`` to fail twice then succeed, run a few
+        ticks, and assert the loop didn't crash and eventually drained.
+        """
+        await _insert(db_conn, SHELF_A, 0, "2026-04-21T08:30:00Z")
+
+        original = db.claim_batch
+        call_count = {"n": 0}
+
+        async def flaky_claim(conn, *, batch_size):  # noqa: ANN001
+            call_count["n"] += 1
+            if call_count["n"] <= 2:
+                raise RuntimeError("simulated DB hiccup")
+            return await original(conn, batch_size=batch_size)
+
+        monkeypatch.setattr("process_b.drainer.db.claim_batch", flaky_claim)
+
+        client = FakeBackendClient()
+        stop = asyncio.Event()
+
+        async def stopper() -> None:
+            await asyncio.sleep(0.2)
+            stop.set()
+
+        await asyncio.gather(
+            run_drainer(
+                db_conn=db_conn,
+                client=client,  # type: ignore[arg-type]
+                interval=0.01,
+                batch_size=50,
+                stop_event=stop,
+            ),
+            stopper(),
+        )
+
+        assert call_count["n"] >= 3
+        assert len(client.posts) >= 1

--- a/process-b/tests/test_ipc.py
+++ b/process-b/tests/test_ipc.py
@@ -1,0 +1,62 @@
+"""Tests for :mod:`process_b.ipc`.
+
+We bind a real loopback UDP socket and assert the bytes on the wire. UDP is
+cheap and synchronous; mocking ``socket.socket`` would be more code than the
+real thing.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+
+import pytest
+
+from process_b import ipc
+
+
+def _free_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+class TestSendWake:
+    def test_sends_expected_json_payload(self) -> None:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as receiver:
+            receiver.bind(("127.0.0.1", 0))
+            receiver.settimeout(1.0)
+            _, port = receiver.getsockname()
+
+            ipc.send_wake("127.0.0.1", port)
+
+            data, _addr = receiver.recvfrom(4096)
+
+        decoded = json.loads(data.decode("utf-8"))
+        assert decoded == {"type": "wake"}
+
+    def test_unreachable_destination_does_not_raise(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Sending to an unbound port on loopback typically does NOT raise
+        # on UDP (the OS reports it asynchronously via ICMP). To force an
+        # actual OSError, we send to an address with an invalid host.
+        # Either outcome — silent success or logged warning — is acceptable;
+        # the contract is "never raises."
+        with caplog.at_level("WARNING", logger="process_b.ipc"):
+            ipc.send_wake("invalid_host_should_fail.local", 65535)
+        # No assertion on log content — the OS may resolve it differently.
+        # The point is: we returned without raising.
+
+    def test_send_wake_uses_ipv4_udp(self) -> None:
+        # Receive on a v4 socket; if send_wake creates a v6 socket it won't
+        # arrive, and the recv timeout will trip.
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as receiver:
+            receiver.bind(("127.0.0.1", 0))
+            receiver.settimeout(1.0)
+            _, port = receiver.getsockname()
+
+            ipc.send_wake("127.0.0.1", port)
+
+            data, _ = receiver.recvfrom(4096)
+            assert data

--- a/process-b/tests/test_logging_setup.py
+++ b/process-b/tests/test_logging_setup.py
@@ -1,0 +1,206 @@
+"""Tests for :mod:`process_b.logging_setup`.
+
+We run real ``logging.LogRecord`` instances through :class:`JsonFormatter`
+and parse the output as JSON. ``configure()`` is exercised through capsys
+so we see what hits stdout in production.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+import pytest
+
+from process_b.logging_setup import JsonFormatter, configure
+
+
+def _make_record(
+    *,
+    name: str = "process_b.test",
+    level: int = logging.INFO,
+    msg: str = "hello",
+    args: tuple = (),
+    extra: dict | None = None,
+) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name=name,
+        level=level,
+        pathname=__file__,
+        lineno=42,
+        msg=msg,
+        args=args,
+        exc_info=None,
+    )
+    if extra:
+        for k, v in extra.items():
+            setattr(record, k, v)
+    return record
+
+
+class TestJsonFormatterShape:
+    def test_emits_single_line_json(self) -> None:
+        formatter = JsonFormatter()
+        line = formatter.format(_make_record())
+
+        assert "\n" not in line
+        parsed = json.loads(line)
+        assert isinstance(parsed, dict)
+
+    def test_required_fields_present(self) -> None:
+        formatter = JsonFormatter()
+        line = formatter.format(_make_record(msg="hi"))
+        parsed = json.loads(line)
+
+        assert parsed["level"] == "INFO"
+        assert parsed["logger"] == "process_b.test"
+        assert parsed["msg"] == "hi"
+        assert "ts" in parsed
+
+    def test_timestamp_format_is_iso_utc_with_millis(self) -> None:
+        formatter = JsonFormatter()
+        line = formatter.format(_make_record())
+        parsed = json.loads(line)
+
+        # 2026-04-21T08:30:00.123Z shape
+        assert re.match(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$", parsed["ts"]
+        )
+
+    def test_message_args_are_interpolated(self) -> None:
+        formatter = JsonFormatter()
+        line = formatter.format(_make_record(msg="count=%d", args=(7,)))
+        parsed = json.loads(line)
+
+        assert parsed["msg"] == "count=7"
+
+
+class TestExtraMerging:
+    def test_extra_keys_merged_at_top_level(self) -> None:
+        formatter = JsonFormatter()
+        line = formatter.format(
+            _make_record(extra={"shelf_id": "abc", "count": 3})
+        )
+        parsed = json.loads(line)
+
+        assert parsed["shelf_id"] == "abc"
+        assert parsed["count"] == 3
+
+    def test_extra_dict_value_is_preserved(self) -> None:
+        formatter = JsonFormatter()
+        line = formatter.format(
+            _make_record(extra={"meta": {"battery": 88, "rssi": -65}})
+        )
+        parsed = json.loads(line)
+
+        assert parsed["meta"] == {"battery": 88, "rssi": -65}
+
+    def test_extra_cannot_overwrite_reserved_top_level_keys(self) -> None:
+        # ``extra={"level": ...}`` would overwrite the LogRecord's levelname
+        # if our formatter blindly merged it. The formatter must drop any
+        # extra key that collides with the reserved top-level shape.
+        formatter = JsonFormatter()
+        line = formatter.format(
+            _make_record(
+                level=logging.INFO,
+                extra={"level": "EMERGENCY", "ts": "fake-ts", "logger": "fake"},
+            )
+        )
+        parsed = json.loads(line)
+
+        assert parsed["level"] == "INFO"
+        assert parsed["logger"] == "process_b.test"
+        # ``ts`` is a real ISO timestamp, not "fake-ts".
+        assert parsed["ts"] != "fake-ts"
+
+    def test_logrecord_internal_attrs_are_not_emitted(self) -> None:
+        formatter = JsonFormatter()
+        line = formatter.format(_make_record())
+        parsed = json.loads(line)
+
+        for attr in ("pathname", "filename", "lineno", "process", "thread"):
+            assert attr not in parsed
+
+    def test_non_serializable_value_falls_back_to_repr(self) -> None:
+        formatter = JsonFormatter()
+
+        class Weird:
+            def __repr__(self) -> str:
+                return "<Weird:42>"
+
+        line = formatter.format(_make_record(extra={"thing": Weird()}))
+        parsed = json.loads(line)
+
+        assert parsed["thing"] == "<Weird:42>"
+
+
+class TestExceptionRendering:
+    def test_logger_exception_emits_exc_field(self) -> None:
+        import sys
+
+        logger = logging.getLogger("process_b.test_exc")
+        logger.handlers = [logging.NullHandler()]
+
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            record = logger.makeRecord(
+                "process_b.test_exc",
+                logging.ERROR,
+                __file__,
+                42,
+                "something broke",
+                None,
+                exc_info=sys.exc_info(),
+            )
+
+        formatter = JsonFormatter()
+        line = formatter.format(record)
+        parsed = json.loads(line)
+
+        assert parsed["msg"] == "something broke"
+        assert "exc" in parsed
+        assert "ValueError" in parsed["exc"]
+        assert "boom" in parsed["exc"]
+
+
+class TestConfigure:
+    def test_configure_is_idempotent_no_handler_stack(self) -> None:
+        configure("INFO")
+        configure("DEBUG")
+        root = logging.getLogger()
+
+        # After two calls we should still have exactly one handler — the
+        # one configure() installed.
+        assert len(root.handlers) == 1
+        assert root.level == logging.DEBUG
+
+    def test_configure_emits_json_on_stdout(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        configure("INFO")
+        logger = logging.getLogger("process_b.test_configure")
+
+        logger.info("hello", extra={"shelf_id": "abc"})
+        captured = capsys.readouterr()
+
+        assert captured.err == ""
+        assert captured.out.count("\n") == 1
+        parsed = json.loads(captured.out.strip())
+        assert parsed["msg"] == "hello"
+        assert parsed["shelf_id"] == "abc"
+
+    def test_configure_respects_level_lowercase(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        configure("warning")
+        logger = logging.getLogger("process_b.test_level")
+
+        logger.info("not visible")
+        logger.warning("visible")
+        captured = capsys.readouterr()
+
+        lines = [line for line in captured.out.split("\n") if line]
+        assert len(lines) == 1
+        assert json.loads(lines[0])["msg"] == "visible"

--- a/process-b/tests/test_main.py
+++ b/process-b/tests/test_main.py
@@ -1,0 +1,151 @@
+"""End-to-end smoke test for :mod:`process_b.main`.
+
+Boots the daemon against:
+
+- a respx-mocked backend (returns 200 on /telemetry, [] on /commands),
+- a tmp-file SQLite DB (so :func:`db.connect` and :func:`db.init` actually
+  run their PRAGMAs and CREATE-TABLE-IF-NOT-EXISTS path),
+- a real loopback UDP socket for the listener,
+- a manual ``stop_event`` we set after observing one telemetry POST.
+
+The point is to verify wiring: did config flow through to all three tasks,
+does the listener bind, does the drainer pick up rows the listener
+inserted, does the poller call /commands with the configured shelves, does
+shutdown actually exit cleanly without orphan tasks?
+
+Per-component behavior is already covered by the focused tests; we don't
+re-test it here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from process_b.config import Config
+from process_b.main import main
+
+
+SHELF_A = "550e8400-e29b-41d4-a716-446655440000"
+BASE_URL = "https://api.example.test"
+
+
+def _free_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def _make_config(tmp_path: Path, *, udp_port: int) -> Config:
+    return Config(
+        pi_api_key="secret",
+        backend_url=BASE_URL,
+        db_path=str(tmp_path / "outbox.db"),
+        shelf_ids=(SHELF_A,),
+        udp_listen_host="127.0.0.1",
+        udp_listen_port=udp_port,
+        proc_a_control_host="127.0.0.1",
+        proc_a_control_port=_free_udp_port(),  # nothing listens, that's fine
+        drain_interval_sec=0.05,
+        drain_batch_size=50,
+        poll_interval_sec=0.05,
+        log_level="INFO",
+    )
+
+
+def _datagram() -> bytes:
+    payload = {
+        "shelf_id": SHELF_A,
+        "scale_index": 0,
+        "est_grams": 750.2,
+        "sampled_at": "2026-04-21T08:30:00Z",
+    }
+    return json.dumps(payload).encode("utf-8")
+
+
+@respx.mock
+async def test_main_wires_listener_drainer_poller_end_to_end(tmp_path: Path) -> None:
+    udp_port = _free_udp_port()
+    config = _make_config(tmp_path, udp_port=udp_port)
+
+    telemetry_route = respx.post(f"{BASE_URL}/telemetry").mock(
+        return_value=httpx.Response(200, json={"accepted": 1, "skipped": []})
+    )
+    commands_route = respx.get(f"{BASE_URL}/commands").mock(
+        return_value=httpx.Response(200, json={"commands": []})
+    )
+
+    daemon_task = asyncio.create_task(main(config))
+
+    async def feed_then_stop() -> None:
+        # Give the listener a moment to bind.
+        for _ in range(50):
+            if telemetry_route.called or daemon_task.done():
+                break
+            await asyncio.sleep(0.02)
+
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sender:
+            sender.sendto(_datagram(), ("127.0.0.1", udp_port))
+
+        # Wait for at least one /telemetry POST to land.
+        for _ in range(100):
+            if telemetry_route.called:
+                break
+            await asyncio.sleep(0.02)
+
+        # Stop the daemon by cancelling — the SIGTERM path is
+        # platform-dependent and tested implicitly by the install code; the
+        # observable shutdown path matters more.
+        daemon_task.cancel()
+
+    await asyncio.gather(feed_then_stop(), daemon_task, return_exceptions=True)
+
+    assert telemetry_route.called, "drainer never POSTed /telemetry"
+
+    request = telemetry_route.calls.last.request
+    body = json.loads(request.content)
+    assert body["shelf_id"] == SHELF_A
+    assert request.headers["Authorization"] == "Bearer secret"
+    assert request.headers["X-Shelf-Id"] == SHELF_A
+    assert len(body["readings"]) == 1
+    assert body["readings"][0]["scale_index"] == 0
+
+    # The poller should have hit /commands at least once with the shelf id.
+    assert commands_route.called, "poller never GET /commands"
+    cmd_request = commands_route.calls.last.request
+    assert cmd_request.headers["X-Shelf-Id"] == SHELF_A
+
+
+async def test_main_exits_cleanly_when_stop_event_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No data path exercised — just verify the daemon boots, runs, and
+    exits cleanly when shutdown is requested before any work happens.
+    """
+    udp_port = _free_udp_port()
+    config = _make_config(tmp_path, udp_port=udp_port)
+
+    with respx.mock:
+        respx.get(f"{BASE_URL}/commands").mock(
+            return_value=httpx.Response(200, json={"commands": []})
+        )
+
+        daemon_task = asyncio.create_task(main(config))
+
+        async def stopper() -> None:
+            await asyncio.sleep(0.1)
+            daemon_task.cancel()
+
+        await asyncio.gather(stopper(), daemon_task, return_exceptions=True)
+
+    # If we got here, the daemon shut down without leaking. Verify the DB
+    # file is closed and rewritable — a cheap proxy for "all aiosqlite
+    # threads finished."
+    db_path = tmp_path / "outbox.db"
+    assert db_path.exists()

--- a/process-b/tests/test_poller.py
+++ b/process-b/tests/test_poller.py
@@ -1,0 +1,357 @@
+"""Tests for :mod:`process_b.poller`.
+
+Strategy
+--------
+- A fake :class:`BackendClient` returns programmable responses per shelf.
+- A fake ``send_wake`` records calls.
+- The clock is injected via ``now_fn`` so expiry tests are deterministic.
+- The loop is exercised end-to-end against a ``stop_event`` we set after
+  one or two ticks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+from process_b.backend_client import (
+    Command,
+    PermanentBackendError,
+    TransientBackendError,
+)
+from process_b.poller import _handle_command, _is_expired, run_poller
+
+
+SHELF_A = "550e8400-e29b-41d4-a716-446655440000"
+SHELF_B = "660e8400-e29b-41d4-a716-446655440001"
+IPC_HOST = "127.0.0.1"
+IPC_PORT = 6001
+NOW = datetime(2026, 4, 21, 8, 30, 0, tzinfo=UTC)
+
+
+def _wake(
+    *,
+    cmd_id: str = "cmd-1",
+    expires_at: str = "2026-04-21T08:35:00Z",
+    payload: object | None = None,
+) -> Command:
+    return Command(id=cmd_id, command="wake", payload=payload, expires_at=expires_at)
+
+
+def _fixed_now() -> datetime:
+    return NOW
+
+
+@dataclass
+class FakeBackendClient:
+    """Programmable :class:`BackendClient` stand-in.
+
+    ``commands_by_shelf`` is a per-shelf queue of *outcomes*. Each outcome
+    is either:
+
+    - ``list[Command]`` — returned to the caller.
+    - an exception instance — raised.
+
+    A shelf with an empty queue returns ``[]`` (no commands).
+    """
+
+    commands_by_shelf: dict[str, deque[object]] = field(
+        default_factory=lambda: defaultdict(deque)
+    )
+    calls_by_shelf: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+
+    def queue(self, shelf_id: str, outcomes: list[object]) -> None:
+        self.commands_by_shelf[shelf_id].extend(outcomes)
+
+    async def get_commands(self, *, shelf_id: str) -> list[Command]:
+        self.calls_by_shelf[shelf_id] += 1
+        q = self.commands_by_shelf.get(shelf_id)
+        if not q:
+            return []
+        outcome = q.popleft()
+        if isinstance(outcome, Exception):
+            raise outcome
+        assert isinstance(outcome, list)
+        return outcome
+
+
+@dataclass
+class FakeIPC:
+    calls: list[tuple[str, int]] = field(default_factory=list)
+
+    def __call__(self, host: str, port: int) -> None:
+        self.calls.append((host, port))
+
+
+class TestIsExpired:
+    def test_future_timestamp_is_live(self) -> None:
+        future = (NOW + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+        assert _is_expired(future, _fixed_now) is False
+
+    def test_past_timestamp_is_expired(self) -> None:
+        past = (NOW - timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+        assert _is_expired(past, _fixed_now) is True
+
+    def test_exactly_now_is_expired(self) -> None:
+        # Boundary: an expires_at equal to "now" is treated as expired.
+        same = NOW.isoformat().replace("+00:00", "Z")
+        assert _is_expired(same, _fixed_now) is True
+
+    def test_unparseable_timestamp_treated_as_live(self) -> None:
+        assert _is_expired("not a date", _fixed_now) is False
+
+    def test_naive_timestamp_assumed_utc(self) -> None:
+        # Without offset/Z; ISO 8601 says ambiguous, we assume UTC.
+        future_naive = (NOW + timedelta(minutes=5)).replace(tzinfo=None).isoformat()
+        assert _is_expired(future_naive, _fixed_now) is False
+
+
+class TestHandleCommand:
+    def test_live_wake_calls_send_wake(self) -> None:
+        ipc = FakeIPC()
+        cmd = _wake(expires_at=(NOW + timedelta(minutes=1)).isoformat().replace("+00:00", "Z"))
+        _handle_command(cmd, SHELF_A, IPC_HOST, IPC_PORT, ipc, _fixed_now)
+        assert ipc.calls == [(IPC_HOST, IPC_PORT)]
+
+    def test_expired_wake_does_not_call_send_wake(self) -> None:
+        ipc = FakeIPC()
+        cmd = _wake(expires_at=(NOW - timedelta(seconds=1)).isoformat().replace("+00:00", "Z"))
+        _handle_command(cmd, SHELF_A, IPC_HOST, IPC_PORT, ipc, _fixed_now)
+        assert ipc.calls == []
+
+    def test_unsupported_command_is_ignored(self) -> None:
+        ipc = FakeIPC()
+        cmd = Command(
+            id="cmd-x",
+            command="reboot",  # not "wake"
+            payload=None,
+            expires_at=(NOW + timedelta(minutes=1)).isoformat().replace("+00:00", "Z"),
+        )
+        _handle_command(cmd, SHELF_A, IPC_HOST, IPC_PORT, ipc, _fixed_now)
+        assert ipc.calls == []
+
+
+class TestPollerLoop:
+    async def test_stop_event_already_set_exits_immediately(self) -> None:
+        client = FakeBackendClient()
+        ipc = FakeIPC()
+        stop = asyncio.Event()
+        stop.set()
+
+        await asyncio.wait_for(
+            run_poller(
+                client=client,  # type: ignore[arg-type]
+                shelf_ids=[SHELF_A],
+                interval=0.01,
+                ipc_host=IPC_HOST,
+                ipc_port=IPC_PORT,
+                stop_event=stop,
+                send_wake=ipc,
+                now_fn=_fixed_now,
+            ),
+            timeout=1.0,
+        )
+        assert client.calls_by_shelf == {}
+        assert ipc.calls == []
+
+    async def test_one_tick_polls_each_shelf_once(self) -> None:
+        client = FakeBackendClient()
+        ipc = FakeIPC()
+        stop = asyncio.Event()
+
+        async def stopper() -> None:
+            await asyncio.sleep(0.03)
+            stop.set()
+
+        await asyncio.gather(
+            run_poller(
+                client=client,  # type: ignore[arg-type]
+                shelf_ids=[SHELF_A, SHELF_B],
+                interval=10.0,  # long; we'll stop before second tick
+                ipc_host=IPC_HOST,
+                ipc_port=IPC_PORT,
+                stop_event=stop,
+                send_wake=ipc,
+                now_fn=_fixed_now,
+            ),
+            stopper(),
+        )
+
+        assert client.calls_by_shelf[SHELF_A] == 1
+        assert client.calls_by_shelf[SHELF_B] == 1
+
+    async def test_live_wake_is_forwarded(self) -> None:
+        client = FakeBackendClient()
+        future = (NOW + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+        client.queue(SHELF_A, [[_wake(cmd_id="cmd-A", expires_at=future)]])
+
+        ipc = FakeIPC()
+        stop = asyncio.Event()
+
+        async def stopper() -> None:
+            await asyncio.sleep(0.03)
+            stop.set()
+
+        await asyncio.gather(
+            run_poller(
+                client=client,  # type: ignore[arg-type]
+                shelf_ids=[SHELF_A],
+                interval=10.0,
+                ipc_host=IPC_HOST,
+                ipc_port=IPC_PORT,
+                stop_event=stop,
+                send_wake=ipc,
+                now_fn=_fixed_now,
+            ),
+            stopper(),
+        )
+
+        assert ipc.calls == [(IPC_HOST, IPC_PORT)]
+
+    async def test_expired_wake_is_dropped(self) -> None:
+        client = FakeBackendClient()
+        past = (NOW - timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+        client.queue(SHELF_A, [[_wake(cmd_id="cmd-A", expires_at=past)]])
+
+        ipc = FakeIPC()
+        stop = asyncio.Event()
+
+        async def stopper() -> None:
+            await asyncio.sleep(0.03)
+            stop.set()
+
+        await asyncio.gather(
+            run_poller(
+                client=client,  # type: ignore[arg-type]
+                shelf_ids=[SHELF_A],
+                interval=10.0,
+                ipc_host=IPC_HOST,
+                ipc_port=IPC_PORT,
+                stop_event=stop,
+                send_wake=ipc,
+                now_fn=_fixed_now,
+            ),
+            stopper(),
+        )
+
+        assert ipc.calls == []
+
+    async def test_transient_failure_one_shelf_does_not_block_other(self) -> None:
+        client = FakeBackendClient()
+        future = (NOW + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+        client.queue(SHELF_A, [TransientBackendError("upstream down", status=503)])
+        client.queue(SHELF_B, [[_wake(cmd_id="cmd-B", expires_at=future)]])
+
+        ipc = FakeIPC()
+        stop = asyncio.Event()
+
+        async def stopper() -> None:
+            await asyncio.sleep(0.03)
+            stop.set()
+
+        await asyncio.gather(
+            run_poller(
+                client=client,  # type: ignore[arg-type]
+                shelf_ids=[SHELF_A, SHELF_B],
+                interval=10.0,
+                ipc_host=IPC_HOST,
+                ipc_port=IPC_PORT,
+                stop_event=stop,
+                send_wake=ipc,
+                now_fn=_fixed_now,
+            ),
+            stopper(),
+        )
+
+        # Both shelves were polled, and the live wake on B was forwarded.
+        assert client.calls_by_shelf[SHELF_A] == 1
+        assert client.calls_by_shelf[SHELF_B] == 1
+        assert ipc.calls == [(IPC_HOST, IPC_PORT)]
+
+    async def test_permanent_failure_does_not_kill_loop(self) -> None:
+        client = FakeBackendClient()
+        client.queue(SHELF_A, [PermanentBackendError("bad token", status=401, body="x")])
+        # Second tick should still happen.
+        future = (NOW + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+        client.queue(SHELF_A, [[_wake(cmd_id="cmd-A", expires_at=future)]])
+
+        ipc = FakeIPC()
+        stop = asyncio.Event()
+
+        async def stopper() -> None:
+            await asyncio.sleep(0.05)  # let two ticks happen at interval=0.01
+            stop.set()
+
+        await asyncio.gather(
+            run_poller(
+                client=client,  # type: ignore[arg-type]
+                shelf_ids=[SHELF_A],
+                interval=0.01,
+                ipc_host=IPC_HOST,
+                ipc_port=IPC_PORT,
+                stop_event=stop,
+                send_wake=ipc,
+                now_fn=_fixed_now,
+            ),
+            stopper(),
+        )
+
+        assert client.calls_by_shelf[SHELF_A] >= 2
+        assert ipc.calls == [(IPC_HOST, IPC_PORT)]
+
+    async def test_unsupported_command_does_not_call_ipc(self) -> None:
+        client = FakeBackendClient()
+        future = (NOW + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+        weird = Command(id="x", command="reboot", payload=None, expires_at=future)
+        client.queue(SHELF_A, [[weird]])
+
+        ipc = FakeIPC()
+        stop = asyncio.Event()
+
+        async def stopper() -> None:
+            await asyncio.sleep(0.03)
+            stop.set()
+
+        await asyncio.gather(
+            run_poller(
+                client=client,  # type: ignore[arg-type]
+                shelf_ids=[SHELF_A],
+                interval=10.0,
+                ipc_host=IPC_HOST,
+                ipc_port=IPC_PORT,
+                stop_event=stop,
+                send_wake=ipc,
+                now_fn=_fixed_now,
+            ),
+            stopper(),
+        )
+
+        assert ipc.calls == []
+
+    async def test_empty_shelf_ids_loop_idles_then_exits(self) -> None:
+        client = FakeBackendClient()
+        ipc = FakeIPC()
+        stop = asyncio.Event()
+
+        async def stopper() -> None:
+            await asyncio.sleep(0.03)
+            stop.set()
+
+        await asyncio.gather(
+            run_poller(
+                client=client,  # type: ignore[arg-type]
+                shelf_ids=[],
+                interval=0.01,
+                ipc_host=IPC_HOST,
+                ipc_port=IPC_PORT,
+                stop_event=stop,
+                send_wake=ipc,
+                now_fn=_fixed_now,
+            ),
+            stopper(),
+        )
+
+        assert client.calls_by_shelf == {}
+        assert ipc.calls == []

--- a/process-b/tests/test_udp_listener.py
+++ b/process-b/tests/test_udp_listener.py
@@ -1,0 +1,251 @@
+"""Tests for :mod:`process_b.udp_listener`.
+
+Two layers of testing:
+
+1. **Protocol-level**: instantiate :class:`TelemetryProtocol` directly and
+   call ``datagram_received`` with raw bytes. No socket. Asserts validation,
+   error paths, and that valid input ends up in the DB.
+
+2. **End-to-end**: ``start_listener`` against a real loopback socket, send
+   a datagram via ``asyncio.DatagramTransport``, then wait for the row to
+   land. One test is enough here — it covers the binding + protocol-wiring
+   path that the protocol-level tests bypass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from collections.abc import AsyncIterator
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from process_b import db
+from process_b.udp_listener import (
+    IncomingReading,
+    TelemetryProtocol,
+    _parse_datagram,
+    start_listener,
+)
+
+
+SHELF_A = "550e8400-e29b-41d4-a716-446655440000"
+LOCAL_ADDR = ("127.0.0.1", 65000)
+
+
+@pytest_asyncio.fixture
+async def db_conn() -> AsyncIterator[aiosqlite.Connection]:
+    conn = await aiosqlite.connect(":memory:")
+    await db.init(conn)
+    try:
+        yield conn
+    finally:
+        await conn.close()
+
+
+def _datagram(
+    *,
+    shelf_id: str = SHELF_A,
+    scale_index: int = 0,
+    est_grams: float = 750.2,
+    sampled_at: str = "2026-04-21T08:30:00Z",
+    extra: dict | None = None,
+) -> bytes:
+    payload = {
+        "shelf_id": shelf_id,
+        "scale_index": scale_index,
+        "est_grams": est_grams,
+        "sampled_at": sampled_at,
+    }
+    if extra:
+        payload.update(extra)
+    return json.dumps(payload).encode("utf-8")
+
+
+async def _wait_for_rows(
+    conn: aiosqlite.Connection, expected: int, timeout: float = 1.0
+) -> list[db.Reading]:
+    """Poll the outbox until ``expected`` rows are visible or timeout."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        rows = await db.claim_batch(conn, batch_size=1000)
+        if len(rows) >= expected:
+            return rows
+        if asyncio.get_running_loop().time() >= deadline:
+            return rows
+        await asyncio.sleep(0.005)
+
+
+async def _drain_protocol_tasks(protocol: TelemetryProtocol) -> None:
+    """Wait for in-flight insert tasks to finish without closing the transport."""
+    if protocol._tasks:  # type: ignore[reportPrivateUsage]
+        await asyncio.gather(
+            *protocol._tasks,  # type: ignore[reportPrivateUsage]
+            return_exceptions=True,
+        )
+
+
+class TestParseDatagram:
+    def test_valid_payload_parses(self) -> None:
+        result = _parse_datagram(_datagram())
+        assert isinstance(result, IncomingReading)
+        assert result.shelf_id == SHELF_A
+        assert result.scale_index == 0
+        assert result.est_grams == pytest.approx(750.2)
+        assert result.sampled_at == "2026-04-21T08:30:00Z"
+
+    def test_invalid_utf8_is_rejected(self) -> None:
+        with pytest.raises(Exception) as exc:
+            _parse_datagram(b"\xff\xfe\xfd not utf-8")
+        assert "utf-8" in str(exc.value)
+
+    def test_invalid_json_is_rejected(self) -> None:
+        with pytest.raises(Exception) as exc:
+            _parse_datagram(b"{not valid json")
+        assert "json" in str(exc.value).lower()
+
+    def test_json_array_root_is_rejected(self) -> None:
+        with pytest.raises(Exception) as exc:
+            _parse_datagram(b"[1, 2, 3]")
+        assert "object" in str(exc.value).lower()
+
+    def test_missing_field_is_rejected(self) -> None:
+        bad = json.dumps({"shelf_id": SHELF_A, "scale_index": 0}).encode("utf-8")
+        with pytest.raises(Exception):
+            _parse_datagram(bad)
+
+    def test_unknown_field_is_rejected_due_to_extra_forbid(self) -> None:
+        with pytest.raises(Exception):
+            _parse_datagram(_datagram(extra={"surprise": "field"}))
+
+    def test_negative_scale_index_is_rejected(self) -> None:
+        with pytest.raises(Exception):
+            _parse_datagram(_datagram(scale_index=-1))
+
+    def test_nan_est_grams_is_rejected(self) -> None:
+        # JSON spec doesn't allow NaN, but Python's json module produces
+        # "NaN" which other parsers accept; pydantic validates after decode.
+        bad = b'{"shelf_id": "%s", "scale_index": 0, "est_grams": NaN, "sampled_at": "2026-04-21T08:30:00Z"}' % SHELF_A.encode()
+        with pytest.raises(Exception):
+            _parse_datagram(bad)
+
+    def test_infinity_est_grams_is_rejected(self) -> None:
+        bad = b'{"shelf_id": "%s", "scale_index": 0, "est_grams": Infinity, "sampled_at": "2026-04-21T08:30:00Z"}' % SHELF_A.encode()
+        with pytest.raises(Exception):
+            _parse_datagram(bad)
+
+    def test_empty_shelf_id_is_rejected(self) -> None:
+        with pytest.raises(Exception):
+            _parse_datagram(_datagram(shelf_id=""))
+
+    def test_empty_sampled_at_is_rejected(self) -> None:
+        with pytest.raises(Exception):
+            _parse_datagram(_datagram(sampled_at=""))
+
+
+class TestProtocolPersistence:
+    async def test_valid_datagram_persists_to_db(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        protocol = TelemetryProtocol(db_conn)
+        protocol.datagram_received(_datagram(), LOCAL_ADDR)
+
+        rows = await _wait_for_rows(db_conn, expected=1)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.shelf_id == SHELF_A
+        assert row.scale_index == 0
+        assert row.est_grams == pytest.approx(750.2)
+        assert row.sampled_at == "2026-04-21T08:30:00Z"
+        assert row.metadata is None
+        assert row.reject_count == 0
+
+    async def test_invalid_datagram_does_not_raise_or_persist(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        protocol = TelemetryProtocol(db_conn)
+
+        protocol.datagram_received(b"not json at all", LOCAL_ADDR)
+        protocol.datagram_received(b"[]", LOCAL_ADDR)
+        protocol.datagram_received(b"\xff\xfe", LOCAL_ADDR)
+
+        await _drain_protocol_tasks(protocol)
+
+        rows = await db.claim_batch(db_conn, batch_size=1000)
+        assert rows == []
+
+    async def test_each_valid_datagram_yields_one_row(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        protocol = TelemetryProtocol(db_conn)
+
+        for i in range(5):
+            protocol.datagram_received(
+                _datagram(scale_index=i, sampled_at=f"2026-04-21T08:30:0{i}Z"),
+                LOCAL_ADDR,
+            )
+
+        rows = await _wait_for_rows(db_conn, expected=5)
+        assert len(rows) == 5
+        assert {r.scale_index for r in rows} == {0, 1, 2, 3, 4}
+
+    async def test_mixed_valid_and_invalid_only_persists_valid(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        protocol = TelemetryProtocol(db_conn)
+
+        protocol.datagram_received(_datagram(scale_index=0), LOCAL_ADDR)
+        protocol.datagram_received(b"garbage", LOCAL_ADDR)
+        protocol.datagram_received(_datagram(scale_index=1, sampled_at="2026-04-21T08:30:01Z"), LOCAL_ADDR)
+        protocol.datagram_received(_datagram(extra={"unexpected": True}), LOCAL_ADDR)
+        protocol.datagram_received(_datagram(scale_index=2, sampled_at="2026-04-21T08:30:02Z"), LOCAL_ADDR)
+
+        rows = await _wait_for_rows(db_conn, expected=3)
+        await _drain_protocol_tasks(protocol)
+        rows = await db.claim_batch(db_conn, batch_size=1000)
+        assert {r.scale_index for r in rows} == {0, 1, 2}
+
+    async def test_aclose_drains_in_flight_tasks(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        protocol = TelemetryProtocol(db_conn)
+
+        for i in range(3):
+            protocol.datagram_received(
+                _datagram(scale_index=i, sampled_at=f"2026-04-21T08:30:0{i}Z"),
+                LOCAL_ADDR,
+            )
+
+        await protocol.aclose()
+
+        rows = await db.claim_batch(db_conn, batch_size=1000)
+        assert len(rows) == 3
+
+
+class TestStartListenerEndToEnd:
+    async def test_real_socket_receives_and_persists(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        # Pick a free ephemeral port deterministically by binding/closing once.
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            free_port = probe.getsockname()[1]
+
+        protocol = await start_listener(
+            db_conn=db_conn, host="127.0.0.1", port=free_port
+        )
+        try:
+            sender = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            try:
+                sender.sendto(_datagram(), ("127.0.0.1", free_port))
+            finally:
+                sender.close()
+
+            rows = await _wait_for_rows(db_conn, expected=1, timeout=2.0)
+            assert len(rows) == 1
+            assert rows[0].shelf_id == SHELF_A
+        finally:
+            await protocol.aclose()


### PR DESCRIPTION
## Related Issue / User Story and BRIEFLY explain what you have done/changed and where

Link the issue or user story this PR belongs to:

- Related to #11 

---

This PR introduces the process-b/ subdirectory containing the full Process B daemon - the broker/persister that runs on the Raspberry Pi between Process A (sampler) and the Cloudflare Worker backend. It also adds a top-level repo layout that reserves process-a/ for the sampler team's eventual code, and updates the root README.md to describe the system.

Process B is a Python 3.11+ asyncio daemon implementing three independent concurrent loops:
- UDP listener (process_b/udp_listener.py) - receives weight readings from Process A, validates with pydantic, persists to a SQLite outbox.
- Drainer (process_b/drainer.py) - every 5s, claims pending readings, groups by shelf_id, POSTs to /telemetry, deletes on 2xx, bumps reject_count on rare whole-batch 4xx, exponential backoff (1s→30s cap) on 5xx/network.
- Poller (process_b/poller.py) - every 3s, GETs /commands per configured shelf, forwards live wake commands to Process A's control port via process_b/ipc.py.
- Supporting modules: config.py (env-var loader), db.py (aiosqlite outbox wrapper), backend_client.py (httpx + pydantic v2), logging_setup.py (JSON-per-line formatter for journald), main.py (resource lifecycle + TaskGroup + SIGTERM handler).

Deployment artifacts under process-b/deploy/: a systemd unit file, env-file template, and a step-by-step Pi deployment runbook (Tailscale-aware).

## Type of change

- [x] New feature (User Story implementation)
- [ ] Task (part of a user story)
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation update

---

## Tested?

- [ ] npm run build passes
- [ ] npm run typecheck passes
- [ ] npm run format:check passes
- [ ] Manual testing done locally

## Notes:

---

## Checklist before requesting review

- [ ] Code follows project style (Prettier)
- [ ] No TypeScript errors
- [ ] CI passes locally (build + typecheck)
- [ ] Linked to issue / user story
- [ ] Small, focused PR (not multiple features)

---

## Notes for reviewers

Anything reviewers should focus on:

- Functional verification on a real Pi happens later once the main branch has both processes. This PR's purpose is only to establish the foundation for process B.
- Tests pass: pytest tests/ → 118 passed in ~7s. Coverage spans config parsing, DB outbox operations, HTTP client error mapping, drainer state machine (including multi-shelf grouping, quarantine, transient backoff), UDP listener (including end-to-end with a real loopback socket), poller (including expired-wake handling), JSON logging, and a main.py smoke test that boots the daemon against a respx-mocked backend and verifies a real datagram makes it through.