### PR TITLE
Feature/orchestration layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ coverage.xml
 # OS
 .DS_Store
 Thumbs.db
+logs/*.log
+logs/*.json
+process-a/baselines.json

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# =============================================================================
+# install.sh  –  SmartShelf deployment script
+# =============================================================================
+# Run once on a freshly flashed Raspberry Pi OS Bookworm (headless).
+# Idempotent – safe to re-run.
+#
+# Usage:
+#   sudo bash install.sh
+# =============================================================================
+
+set -euo pipefail
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+fatal() { echo -e "${RED}[FATAL]${NC} $*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || fatal "Must be run as root (sudo bash install.sh)"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="/opt/smartshelf"
+SERVICE_FILE="smartshelf-orchestrator.service"
+
+# ── 1. Dependencies ──────────────────────────────────────────────────────────
+info "Installing system dependencies …"
+apt-get update -qq
+apt-get install -y --no-install-recommends \
+    python3 python3-pip network-manager iproute2 iputils-ping
+
+# ── 2. Install Python deps ────────────────────────────────────────────────────
+info "Installing Python packages …"
+pip3 install --break-system-packages --quiet psutil
+
+# ── 3. Deploy application files ───────────────────────────────────────────────
+info "Deploying application to $INSTALL_DIR …"
+mkdir -p "$INSTALL_DIR"
+cp "$SCRIPT_DIR/orchestrator.py"   "$INSTALL_DIR/"
+cp "$SCRIPT_DIR/wifi_connector.py" "$INSTALL_DIR/"
+chmod 755 "$INSTALL_DIR/orchestrator.py"
+chmod 644 "$INSTALL_DIR/wifi_connector.py"
+
+# Placeholder stubs so the service can start even without real processes
+for proc in process_a process_b process_c; do
+    target="$INSTALL_DIR/${proc}.py"
+    if [[ ! -f "$target" ]]; then
+        warn "Stub: $target not found – creating placeholder."
+        cat > "$target" <<STUB
+#!/usr/bin/env python3
+import time, logging
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("${proc}")
+log.info("${proc} placeholder running – replace with real implementation.")
+while True:
+    time.sleep(60)
+STUB
+        chmod 755 "$target"
+    fi
+done
+
+# ── 4. State directory ────────────────────────────────────────────────────────
+mkdir -p /var/lib/smartshelf
+chmod 750 /var/lib/smartshelf
+
+# ── 5. Log directory ─────────────────────────────────────────────────────────
+touch /var/log/smartshelf_orchestrator.log
+chmod 640 /var/log/smartshelf_orchestrator.log
+
+# ── 6. NetworkManager – ensure it's running ───────────────────────────────────
+info "Enabling NetworkManager …"
+systemctl enable NetworkManager
+systemctl start  NetworkManager
+
+# Wait for NM to be available
+for i in {1..10}; do
+    nmcli general status &>/dev/null && break
+    warn "Waiting for nmcli ($i/10) …"; sleep 2
+done
+
+# ── 7. Pre-configure the AP hotspot profile ───────────────────────────────────
+info "Configuring AP hotspot profile …"
+bash "$SCRIPT_DIR/smartshelf_network_setup.sh"
+
+# ── 8. Install and enable the systemd service ────────────────────────────────
+info "Installing systemd service …"
+cp "$SCRIPT_DIR/$SERVICE_FILE" /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable "$SERVICE_FILE"
+
+info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+info "Installation complete."
+info ""
+info "Start the service now:  systemctl start smartshelf-orchestrator"
+info "Watch live logs:        journalctl -fu smartshelf-orchestrator"
+info "Or tail the file:       tail -f /var/log/smartshelf_orchestrator.log"
+info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 # =============================================================================
-# install.sh  –  SmartShelf deployment script
+# install.sh  –  ShelfAware deployment script
 # =============================================================================
 # Run once on a freshly flashed Raspberry Pi OS Bookworm (headless).
 # Idempotent – safe to re-run.
+#
+# ⚠️  TAILSCALE WARNING: This script calls nmcli and systemctl which will
+#     modify NetworkManager and may sever your remote connection.
+#     Run from a local terminal or physical keyboard/monitor only.
 #
 # Usage:
 #   sudo bash install.sh
@@ -19,8 +23,9 @@ fatal() { echo -e "${RED}[FATAL]${NC} $*" >&2; exit 1; }
 [[ $EUID -eq 0 ]] || fatal "Must be run as root (sudo bash install.sh)"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-INSTALL_DIR="/opt/smartshelf"
-SERVICE_FILE="smartshelf-orchestrator.service"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_DIR="/opt/shelfaware"
+SERVICE_FILE="shelfaware-orchestrator.service"
 
 # ── 1. Dependencies ──────────────────────────────────────────────────────────
 info "Installing system dependencies …"
@@ -30,58 +35,72 @@ apt-get install -y --no-install-recommends \
 
 # ── 2. Install Python deps ────────────────────────────────────────────────────
 info "Installing Python packages …"
-pip3 install --break-system-packages --quiet psutil
+pip3 install --break-system-packages --quiet \
+    adafruit-blinka \
+    adafruit-circuitpython-ads1x15
 
 # ── 3. Deploy application files ───────────────────────────────────────────────
 info "Deploying application to $INSTALL_DIR …"
-mkdir -p "$INSTALL_DIR"
-cp "$SCRIPT_DIR/orchestrator.py"   "$INSTALL_DIR/"
-cp "$SCRIPT_DIR/wifi_connector.py" "$INSTALL_DIR/"
-chmod 755 "$INSTALL_DIR/orchestrator.py"
-chmod 644 "$INSTALL_DIR/wifi_connector.py"
+mkdir -p "$INSTALL_DIR/orchestration"
+mkdir -p "$INSTALL_DIR/process-a"
+mkdir -p "$INSTALL_DIR/process-b/process_b"
+mkdir -p "$INSTALL_DIR/process-c"
 
-# Placeholder stubs so the service can start even without real processes
-for proc in process_a process_b process_c; do
-    target="$INSTALL_DIR/${proc}.py"
-    if [[ ! -f "$target" ]]; then
-        warn "Stub: $target not found – creating placeholder."
-        cat > "$target" <<STUB
+# Orchestration layer
+cp "$REPO_ROOT/orchestration/orchestrator.py"              "$INSTALL_DIR/orchestration/"
+cp "$REPO_ROOT/orchestration/wifi_connector.py"            "$INSTALL_DIR/orchestration/"
+cp "$REPO_ROOT/orchestration/shelfaware_network_setup.sh"  "$INSTALL_DIR/orchestration/"
+chmod 755 "$INSTALL_DIR/orchestration/orchestrator.py"
+chmod 644 "$INSTALL_DIR/orchestration/wifi_connector.py"
+chmod 755 "$INSTALL_DIR/orchestration/shelfaware_network_setup.sh"
+
+# Process A
+cp "$REPO_ROOT/process-a/process_A.py" "$INSTALL_DIR/process-a/"
+chmod 755 "$INSTALL_DIR/process-a/process_A.py"
+
+# Process B
+cp -r "$REPO_ROOT/process-b/process_b/." "$INSTALL_DIR/process-b/process_b/"
+
+# Process C (placeholder until ready)
+if [[ -f "$REPO_ROOT/process-c/process_c.py" ]]; then
+    cp "$REPO_ROOT/process-c/process_c.py" "$INSTALL_DIR/process-c/"
+    chmod 755 "$INSTALL_DIR/process-c/process_c.py"
+else
+    warn "process_c.py not found – creating placeholder stub."
+    cat > "$INSTALL_DIR/process-c/process_c.py" <<STUB
 #!/usr/bin/env python3
 import time, logging
 logging.basicConfig(level=logging.INFO)
-log = logging.getLogger("${proc}")
-log.info("${proc} placeholder running – replace with real implementation.")
+log = logging.getLogger("process_c")
+log.info("process_c placeholder – replace with real implementation.")
 while True:
     time.sleep(60)
 STUB
-        chmod 755 "$target"
-    fi
-done
+    chmod 755 "$INSTALL_DIR/process-c/process_c.py"
+fi
 
-# ── 4. State directory ────────────────────────────────────────────────────────
-mkdir -p /var/lib/smartshelf
-chmod 750 /var/lib/smartshelf
+# ── 4. State and log directories ──────────────────────────────────────────────
+mkdir -p /var/lib/shelfaware
+chmod 750 /var/lib/shelfaware
 
-# ── 5. Log directory ─────────────────────────────────────────────────────────
-touch /var/log/smartshelf_orchestrator.log
-chmod 640 /var/log/smartshelf_orchestrator.log
+touch /var/log/shelfaware_orchestrator.log
+chmod 640 /var/log/shelfaware_orchestrator.log
 
-# ── 6. NetworkManager – ensure it's running ───────────────────────────────────
+# ── 5. NetworkManager – ensure it's running ───────────────────────────────────
 info "Enabling NetworkManager …"
 systemctl enable NetworkManager
 systemctl start  NetworkManager
 
-# Wait for NM to be available
 for i in {1..10}; do
     nmcli general status &>/dev/null && break
     warn "Waiting for nmcli ($i/10) …"; sleep 2
 done
 
-# ── 7. Pre-configure the AP hotspot profile ───────────────────────────────────
+# ── 6. Pre-configure the AP hotspot profile ───────────────────────────────────
 info "Configuring AP hotspot profile …"
-bash "$SCRIPT_DIR/smartshelf_network_setup.sh"
+bash "$INSTALL_DIR/orchestration/shelfaware_network_setup.sh"
 
-# ── 8. Install and enable the systemd service ────────────────────────────────
+# ── 7. Install and enable the systemd service ─────────────────────────────────
 info "Installing systemd service …"
 cp "$SCRIPT_DIR/$SERVICE_FILE" /etc/systemd/system/
 systemctl daemon-reload
@@ -90,7 +109,7 @@ systemctl enable "$SERVICE_FILE"
 info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 info "Installation complete."
 info ""
-info "Start the service now:  systemctl start smartshelf-orchestrator"
-info "Watch live logs:        journalctl -fu smartshelf-orchestrator"
-info "Or tail the file:       tail -f /var/log/smartshelf_orchestrator.log"
+info "Start the service now:  systemctl start shelfaware-orchestrator"
+info "Watch live logs:        journalctl -fu shelfaware-orchestrator"
+info "Or tail the file:       tail -f /var/log/shelfaware_orchestrator.log"
 info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -51,7 +51,7 @@ info "Deploying application to $INSTALL_DIR …"
 mkdir -p "$INSTALL_DIR/orchestration"
 mkdir -p "$INSTALL_DIR/process-a"
 mkdir -p "$INSTALL_DIR/process-b/process_b"
-mkdir -p "$INSTALL_DIR/process-c"
+mkdir -p "$INSTALL_DIR/process-c/process_c"
 
 # Orchestration layer
 cp "$REPO_ROOT/orchestration/orchestrator.py"              "$INSTALL_DIR/orchestration/"
@@ -75,12 +75,22 @@ fi
 info "Installing Process B's Python dependencies …"
 pip3 install --break-system-packages --quiet -e "$INSTALL_DIR/process-b"
 
-# Process C (placeholder until ready)
-if [[ -f "$REPO_ROOT/process-c/process_c.py" ]]; then
-    cp "$REPO_ROOT/process-c/process_c.py" "$INSTALL_DIR/process-c/"
+# Process C: stage source AND pyproject so we can pip install from $INSTALL_DIR.
+# The orchestrator launches it via /opt/shelfaware/process-c/process_c.py
+# (a small shim that forwards to process_c.main:run on the installed package).
+if [[ -d "$REPO_ROOT/process-c/process_c" ]]; then
+    cp -r "$REPO_ROOT/process-c/process_c/." "$INSTALL_DIR/process-c/process_c/"
+    cp    "$REPO_ROOT/process-c/pyproject.toml" "$INSTALL_DIR/process-c/"
+    if [[ -f "$REPO_ROOT/process-c/README.md" ]]; then
+        cp "$REPO_ROOT/process-c/README.md" "$INSTALL_DIR/process-c/"
+    fi
+    cp "$REPO_ROOT/process-c/process_c.py" "$INSTALL_DIR/process-c/process_c.py"
     chmod 755 "$INSTALL_DIR/process-c/process_c.py"
+
+    info "Installing Process C's Python dependencies …"
+    pip3 install --break-system-packages --quiet -e "$INSTALL_DIR/process-c"
 else
-    warn "process_c.py not found – creating placeholder stub."
+    warn "process-c package not found – creating placeholder stub."
     cat > "$INSTALL_DIR/process-c/process_c.py" <<STUB
 #!/usr/bin/env python3
 import time, logging

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -35,9 +35,16 @@ apt-get install -y --no-install-recommends \
 
 # ── 2. Install Python deps ────────────────────────────────────────────────────
 info "Installing Python packages …"
+
+# Process A: hardware drivers
 pip3 install --break-system-packages --quiet \
     adafruit-blinka \
     adafruit-circuitpython-ads1x15
+
+# Process B's runtime deps are installed in section 3 below, AFTER its
+# source has been staged to $INSTALL_DIR. Installing here would either
+# pin to the repo working tree (wrong: /opt is the source of truth in
+# production) or fail (no pyproject.toml in $INSTALL_DIR yet).
 
 # ── 3. Deploy application files ───────────────────────────────────────────────
 info "Deploying application to $INSTALL_DIR …"
@@ -58,8 +65,15 @@ chmod 755 "$INSTALL_DIR/orchestration/shelfaware_network_setup.sh"
 cp "$REPO_ROOT/process-a/process_A.py" "$INSTALL_DIR/process-a/"
 chmod 755 "$INSTALL_DIR/process-a/process_A.py"
 
-# Process B
+# Process B: stage source AND pyproject so we can pip install from $INSTALL_DIR
 cp -r "$REPO_ROOT/process-b/process_b/." "$INSTALL_DIR/process-b/process_b/"
+cp    "$REPO_ROOT/process-b/pyproject.toml" "$INSTALL_DIR/process-b/"
+if [[ -f "$REPO_ROOT/process-b/README.md" ]]; then
+    cp "$REPO_ROOT/process-b/README.md" "$INSTALL_DIR/process-b/"
+fi
+
+info "Installing Process B's Python dependencies …"
+pip3 install --break-system-packages --quiet -e "$INSTALL_DIR/process-b"
 
 # Process C (placeholder until ready)
 if [[ -f "$REPO_ROOT/process-c/process_c.py" ]]; then
@@ -85,6 +99,39 @@ chmod 750 /var/lib/shelfaware
 
 touch /var/log/shelfaware_orchestrator.log
 chmod 640 /var/log/shelfaware_orchestrator.log
+
+# ── 4b. Process B environment file ────────────────────────────────────────────
+# Process B reads PI_API_KEY, BACKEND_URL, SHELF_IDS, DB_PATH, etc. from env.
+# The systemd unit loads them from /etc/shelfaware/process-b.env.
+# If the file doesn't already exist, drop a template that the operator must
+# fill in BEFORE the orchestrator first launches Process B.
+mkdir -p /etc/shelfaware
+chmod 750 /etc/shelfaware
+
+PROCESS_B_ENV="/etc/shelfaware/process-b.env"
+if [[ ! -f "$PROCESS_B_ENV" ]]; then
+    info "Creating Process B env template at $PROCESS_B_ENV …"
+    if [[ -f "$REPO_ROOT/process-b/deploy/process-b.env.example" ]]; then
+        cp "$REPO_ROOT/process-b/deploy/process-b.env.example" "$PROCESS_B_ENV"
+    else
+        cat > "$PROCESS_B_ENV" <<'ENV_TEMPLATE'
+# Process B environment file. Loaded by the orchestrator's systemd unit.
+# Fill in real values before starting shelfaware-orchestrator.
+PI_API_KEY=changeme
+BACKEND_URL=https://shelfaware-backend.example.workers.dev
+SHELF_IDS=00000000-0000-0000-0000-000000000000
+DB_PATH=/var/lib/shelfaware/process-b.sqlite
+UDP_LISTEN_HOST=127.0.0.1
+UDP_LISTEN_PORT=5005
+PROC_A_CONTROL_HOST=127.0.0.1
+PROC_A_CONTROL_PORT=5006
+ENV_TEMPLATE
+    fi
+    chmod 640 "$PROCESS_B_ENV"
+    warn "Edit $PROCESS_B_ENV with real values before starting the service."
+else
+    info "Process B env file already exists at $PROCESS_B_ENV – leaving untouched."
+fi
 
 # ── 5. NetworkManager – ensure it's running ───────────────────────────────────
 info "Enabling NetworkManager …"

--- a/deploy/shelfaware-orchestrator.service
+++ b/deploy/shelfaware-orchestrator.service
@@ -1,0 +1,71 @@
+# /etc/systemd/system/shelfaware-orchestrator.service
+#
+# ShelfAware Boot Orchestrator
+# ════════════════════════════
+# Install and enable:
+#   sudo cp shelfaware-orchestrator.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable shelfaware-orchestrator.service
+#
+# ⚠️  TAILSCALE WARNING: Enabling and starting this service will invoke
+#     the orchestrator which calls nmcli. Only enable when physically
+#     present at the Pi or when Tailscale access is not required.
+#     During development, use SHELFAWARE_DEV=1 and run orchestrator.py
+#     directly instead of via systemd.
+#
+# Check logs:
+#   journalctl -fu shelfaware-orchestrator
+#   tail -f /var/log/shelfaware_orchestrator.log
+
+[Unit]
+Description=ShelfAware Boot Orchestrator
+Documentation=file:///opt/shelfaware/README.md
+
+# Hard dependency – if NM dies, we stop too (no ghost state)
+Requires=NetworkManager.service
+After=NetworkManager.service
+
+# Belt-and-suspenders for slow DHCP boot environments
+Wants=network-online.target
+After=network-online.target
+
+After=time-sync.target
+
+[Service]
+Type=simple
+
+User=root
+Group=root
+
+# Unset DEV mode in production – explicitly enforce it
+Environment="SHELFAWARE_DEV=0"
+Environment="PYTHONUNBUFFERED=1"
+Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+WorkingDirectory=/opt/shelfaware
+ExecStart=/usr/bin/python3 /opt/shelfaware/orchestration/orchestrator.py
+
+# systemd creates /var/lib/shelfaware with correct permissions before launch
+StateDirectory=shelfaware
+StateDirectoryMode=0750
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=shelfaware-orchestrator
+
+# Restart on failure, not on clean exit (clean exit = intentional stop)
+Restart=on-failure
+RestartSec=10
+
+# Max 3 restarts per 60 s – prevents CPU-hogging boot loops
+StartLimitIntervalSec=60
+StartLimitBurst=3
+StartLimitAction=none
+
+# Kill entire cgroup (all child processes) on stop
+KillMode=control-group
+TimeoutStopSec=15
+
+[Install]
+WantedBy=multi-user.target
+

--- a/deploy/shelfaware-orchestrator.service
+++ b/deploy/shelfaware-orchestrator.service
@@ -42,6 +42,12 @@ Environment="SHELFAWARE_DEV=0"
 Environment="PYTHONUNBUFFERED=1"
 Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
+# Process B reads its config from env vars (PI_API_KEY, BACKEND_URL,
+# SHELF_IDS, DB_PATH, ...). The orchestrator inherits this environment
+# and passes it through to Process B when it spawns it as a subprocess.
+# The file is created by deploy/install.sh; operator fills in real values.
+EnvironmentFile=/etc/shelfaware/process-b.env
+
 WorkingDirectory=/opt/shelfaware
 ExecStart=/usr/bin/python3 /opt/shelfaware/orchestration/orchestrator.py
 

--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""
+orchestrator.py  –  ShelfAware Boot Orchestrator
+═════════════════════════════════════════════════
+Execution flow:
+  1. Poll NetworkManager readiness (up to 30 s).
+  2. Ping 8.8.8.8 to verify internet connectivity (timeout 10 s).
+  3a. Internet OK  → kill B/C, launch Process A.
+  3b. No internet  → kill A, switch to AP mode, launch Process C then B.
+
+DEV_MODE  (SHELFAWARE_DEV=1):
+  All nmcli / NetworkManager calls are short-circuited.
+  Safe to run over Tailscale / mobile hotspot during development.
+  Export SHELFAWARE_DEV=1 before running to activate.
+
+Defensive guarantees:
+  • Every subprocess call is time-bounded.
+  • Opposing process group is fully reaped before new one starts.
+  • Rolling log → /var/log/shelfaware_orchestrator.log (5 MB × 3).
+  • Consecutive-failure state file prevents silent brick loops.
+  • SIGTERM → SIGKILL escalation with configurable grace period.
+"""
+
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Optional
+
+# ──────────────────────────────────────────────
+# DEV MODE  –  set SHELFAWARE_DEV=1 to activate
+# ──────────────────────────────────────────────
+DEV_MODE = os.environ.get("SHELFAWARE_DEV", "0") == "1"
+
+# ──────────────────────────────────────────────
+# Configuration
+# ──────────────────────────────────────────────
+LOG_FILE         = Path("/home/group2/group2/ShelfAware-IoT/logs/shelfaware_orchestrator.log")
+LOG_MAX_BYTES    = 5 * 1024 * 1024
+LOG_BACKUP_COUNT = 3
+
+if DEV_MODE:
+    BASE = Path("/home/group2/group2/ShelfAware-IoT")
+    STATE_FILE    = BASE / "logs/orchestrator_state.json"
+    PROCESS_A_CMD = [sys.executable, str(BASE / "process-a/process_A.py")]
+    PROCESS_B_CMD = [sys.executable, str(BASE / "process-b/process_b/main.py")]
+    PROCESS_C_CMD = [sys.executable, str(BASE / "process-c/process_c.py")]
+else:
+    STATE_FILE    = Path("/var/lib/shelfaware/orchestrator_state.json")
+    PROCESS_A_CMD = [sys.executable, "/opt/shelfaware/process-a/process_A.py"]
+    PROCESS_B_CMD = [sys.executable, "/opt/shelfaware/process-b/process_b/main.py"]
+    PROCESS_C_CMD = [sys.executable, "/opt/shelfaware/process-c/process_c.py"]
+
+PING_HOST        = "8.8.8.8"
+PING_TIMEOUT_SEC = 10
+PING_COUNT       = 3
+
+NM_READY_TIMEOUT = 30
+NM_POLL_INTERVAL = 2
+
+AP_PROFILE_NAME  = "ShelfAware_Setup"
+CONNECT_TIMEOUT  = 30
+
+PROC_TERM_GRACE  = 5
+MAX_FAILURES     = 5
+
+# ──────────────────────────────────────────────
+# Logging
+# ──────────────────────────────────────────────
+
+def _build_logger() -> logging.Logger:
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+    fmt = logging.Formatter(
+        "%(asctime)s  %(levelname)-8s  %(funcName)-30s  %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+    handler = RotatingFileHandler(
+        LOG_FILE,
+        maxBytes=LOG_MAX_BYTES,
+        backupCount=LOG_BACKUP_COUNT,
+    )
+    handler.setFormatter(fmt)
+
+    console = logging.StreamHandler(sys.stdout)
+    console.setFormatter(fmt)
+
+    log = logging.getLogger("shelfaware.orchestrator")
+    log.setLevel(logging.DEBUG)
+    log.addHandler(handler)
+    log.addHandler(console)
+    return log
+
+
+log = _build_logger()
+
+# ──────────────────────────────────────────────
+# State persistence
+# ──────────────────────────────────────────────
+
+def _load_state() -> dict:
+    try:
+        STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        if STATE_FILE.exists():
+            return json.loads(STATE_FILE.read_text())
+    except Exception as exc:
+        log.warning("Could not read state file: %s", exc)
+    return {"consecutive_failures": 0, "last_mode": None}
+
+
+def _save_state(state: dict) -> None:
+    try:
+        STATE_FILE.write_text(json.dumps(state, indent=2))
+    except Exception as exc:
+        log.warning("Could not write state file: %s", exc)
+
+
+# ──────────────────────────────────────────────
+# NetworkManager readiness guard
+# ──────────────────────────────────────────────
+
+def wait_for_networkmanager(timeout: int = NM_READY_TIMEOUT) -> bool:
+    if DEV_MODE:
+        log.info("[DEV MODE] Skipping NetworkManager readiness check — returning True.")
+        return True
+
+    deadline = time.monotonic() + timeout
+    log.info("Waiting up to %d s for NetworkManager to be ready …", timeout)
+
+    while time.monotonic() < deadline:
+        try:
+            result = subprocess.run(
+                ["nmcli", "general", "status"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                log.info("NetworkManager is ready.")
+                return True
+        except subprocess.TimeoutExpired:
+            log.debug("nmcli status timed out – NM still starting.")
+        except FileNotFoundError:
+            log.critical("nmcli not found. Is NetworkManager installed?")
+            return False
+        except Exception as exc:
+            log.debug("nmcli status error: %s", exc)
+
+        time.sleep(NM_POLL_INTERVAL)
+
+    log.error("NetworkManager did not become ready within %d s.", timeout)
+    return False
+
+
+# ──────────────────────────────────────────────
+# Internet connectivity check
+# ──────────────────────────────────────────────
+
+def has_internet(host: str = PING_HOST, count: int = PING_COUNT,
+                 timeout: int = PING_TIMEOUT_SEC) -> bool:
+    if DEV_MODE:
+        log.info("[DEV MODE] Skipping ping check — simulating ONLINE.")
+        return True
+
+    cmd = ["ping", "-c", str(count), "-W", str(timeout), host]
+    log.info("Checking internet: %s", " ".join(cmd))
+
+    try:
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout + 5,
+        )
+        reachable = result.returncode == 0
+        log.info("Internet check → %s", "ONLINE" if reachable else "OFFLINE")
+        return reachable
+
+    except subprocess.TimeoutExpired:
+        log.error("Ping command timed out after %d s.", timeout + 5)
+        return False
+    except FileNotFoundError:
+        log.critical("`ping` binary not found.")
+        return False
+    except Exception as exc:
+        log.error("Unexpected ping error: %s", exc, exc_info=True)
+        return False
+
+
+# ──────────────────────────────────────────────
+# Process management
+# ──────────────────────────────────────────────
+
+_running: dict[str, Optional[subprocess.Popen]] = {
+    "A": None,
+    "B": None,
+    "C": None,
+}
+
+
+def _kill_process(name: str, grace: int = PROC_TERM_GRACE) -> None:
+    proc: Optional[subprocess.Popen] = _running.get(name)
+
+    if proc is None:
+        log.debug("Process %s: no handle tracked, skipping kill.", name)
+        return
+
+    if proc.poll() is not None:
+        log.debug("Process %s (PID %d) already exited with code %s.",
+                  name, proc.pid, proc.returncode)
+        _running[name] = None
+        return
+
+    log.info("Sending SIGTERM to Process %s (PID %d) …", name, proc.pid)
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except (ProcessLookupError, PermissionError) as exc:
+        log.warning("SIGTERM to %s failed: %s", name, exc)
+
+    try:
+        proc.wait(timeout=grace)
+        log.info("Process %s exited cleanly after SIGTERM.", name)
+    except subprocess.TimeoutExpired:
+        log.warning("Process %s did not exit in %d s – escalating to SIGKILL.",
+                    name, grace)
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            proc.wait(timeout=3)
+            log.info("Process %s killed via SIGKILL.", name)
+        except Exception as exc:
+            log.error("SIGKILL to Process %s failed: %s", name, exc)
+    except Exception as exc:
+        log.error("Unexpected error waiting on Process %s: %s", name, exc)
+
+    _running[name] = None
+
+
+def _kill_group(*names: str) -> None:
+    for name in names:
+        _kill_process(name)
+
+
+def _launch_process(name: str, cmd: list[str]) -> Optional[subprocess.Popen]:
+    log.info("Launching Process %s: %s", name, " ".join(cmd))
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        _running[name] = proc
+        log.info("Process %s started (PID %d).", name, proc.pid)
+        return proc
+    except FileNotFoundError:
+        log.critical("Process %s executable not found: %s", name, cmd[0])
+    except PermissionError:
+        log.critical("Process %s: permission denied executing %s.", name, cmd[0])
+    except Exception as exc:
+        log.critical("Process %s failed to start: %s", name, exc, exc_info=True)
+
+    _running[name] = None
+    return None
+
+
+# ──────────────────────────────────────────────
+# NetworkManager / AP helpers
+# ──────────────────────────────────────────────
+
+def _nmcli(*args: str, timeout: int = 15) -> subprocess.CompletedProcess:
+    cmd = ["nmcli"] + list(args)
+    log.debug("nmcli cmd: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if result.returncode != 0:
+        log.error("nmcli error (rc=%d): %s", result.returncode, result.stderr.strip())
+        result.check_returncode()
+    return result
+
+
+def switch_to_ap_mode() -> bool:
+    if DEV_MODE:
+        log.info(
+            "[DEV MODE] Skipping AP mode switch — would run: "
+            "nmcli connection up '%s'. Returning True.", AP_PROFILE_NAME
+        )
+        return True
+
+    log.info("Switching to AP mode (profile: %s) …", AP_PROFILE_NAME)
+    try:
+        _nmcli("device", "disconnect", "wlan0", timeout=10)
+    except Exception:
+        pass
+
+    try:
+        _nmcli("connection", "up", AP_PROFILE_NAME, timeout=20)
+        log.info("AP mode active.")
+        return True
+    except subprocess.TimeoutExpired:
+        log.error("Timed out activating AP profile.")
+    except subprocess.CalledProcessError as exc:
+        log.error("Failed to activate AP profile: %s", exc)
+    except Exception as exc:
+        log.error("Unexpected AP switch error: %s", exc, exc_info=True)
+    return False
+
+
+# ──────────────────────────────────────────────
+# Main orchestration logic
+# ──────────────────────────────────────────────
+
+def run_online_mode() -> None:
+    log.info("=== ONLINE MODE ===")
+    _kill_group("B", "C")
+
+    if _running["A"] and _running["A"].poll() is None:
+        log.info("Process A already running (PID %d) – no action needed.",
+                 _running["A"].pid)
+        return
+
+    _launch_process("A", PROCESS_A_CMD)
+
+
+def run_offline_mode() -> None:
+    log.info("=== OFFLINE / SETUP MODE ===")
+    _kill_group("A")
+
+    if not switch_to_ap_mode():
+        log.critical("Cannot enter AP mode. Orchestrator cannot proceed safely.")
+        raise RuntimeError("AP mode switch failed")
+
+    time.sleep(3)
+
+    if not (_running["C"] and _running["C"].poll() is None):
+        _launch_process("C", PROCESS_C_CMD)
+        time.sleep(2)
+
+    if not (_running["B"] and _running["B"].poll() is None):
+        _launch_process("B", PROCESS_B_CMD)
+
+
+def main() -> None:
+    log.info("━" * 60)
+    log.info("ShelfAware Orchestrator starting (PID %d).", os.getpid())
+
+    if DEV_MODE:
+        log.warning(
+            "[DEV MODE] SHELFAWARE_DEV=1 — all nmcli/NM calls are "
+            "short-circuited. Safe for Tailscale / hotspot development."
+        )
+
+    state = _load_state()
+
+    if state["consecutive_failures"] >= MAX_FAILURES:
+        log.critical(
+            "Exceeded %d consecutive failures. Refusing to loop. "
+            "Manual intervention required. Entering AP mode as safe fallback.",
+            MAX_FAILURES,
+        )
+        switch_to_ap_mode()
+        sys.exit(1)
+
+    if not wait_for_networkmanager():
+        state["consecutive_failures"] += 1
+        _save_state(state)
+        log.critical("NetworkManager unavailable. Aborting.")
+        sys.exit(1)
+
+    try:
+        online = has_internet()
+    except Exception as exc:
+        log.error("Internet check raised an unexpected exception: %s", exc,
+                  exc_info=True)
+        online = False
+
+    try:
+        if online:
+            run_online_mode()
+            state["last_mode"] = "online"
+        else:
+            run_offline_mode()
+            state["last_mode"] = "offline"
+
+        state["consecutive_failures"] = 0
+        _save_state(state)
+
+    except Exception as exc:
+        log.critical("Orchestrator encountered a fatal error: %s", exc,
+                     exc_info=True)
+        state["consecutive_failures"] += 1
+        _save_state(state)
+        sys.exit(1)
+
+    log.info("Orchestrator entering steady-state monitor loop.")
+    check_interval = 60
+
+    while True:
+        time.sleep(check_interval)
+
+        try:
+            still_online = has_internet()
+        except Exception as exc:
+            log.warning("Periodic internet check failed: %s", exc)
+            continue
+
+        if still_online and state["last_mode"] != "online":
+            log.info("Network recovered – switching to online mode.")
+            run_online_mode()
+            state["last_mode"] = "online"
+            _save_state(state)
+
+        elif not still_online and state["last_mode"] != "offline":
+            log.warning("Network lost – switching to offline/setup mode.")
+            run_offline_mode()
+            state["last_mode"] = "offline"
+            _save_state(state)
+
+        for name, proc in _running.items():
+            if proc is not None:
+                rc = proc.poll()
+                if rc is not None:
+                    log.warning("Process %s (PID %d) exited unexpectedly "
+                                "with code %d.", name, proc.pid, rc)
+                    _running[name] = None
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        log.info("Orchestrator stopped by keyboard interrupt.")
+    except Exception as exc:
+        log.critical("Orchestrator crashed: %s", exc, exc_info=True)
+        raise

--- a/orchestration/shelfaware_network_setup.sh
+++ b/orchestration/shelfaware_network_setup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# =============================================================================
+# shelfaware_network_setup.sh
+# =============================================================================
+# Run ONCE during factory provisioning (or first-time setup) on the Pi.
+# Idempotent – safe to re-run.
+#
+# ⚠️  TAILSCALE WARNING: This script calls nmcli and will modify
+#     NetworkManager profiles. Do NOT run this over a remote Tailscale /
+#     hotspot session unless you are prepared to lose the connection.
+#     Run from a local terminal or physical keyboard/monitor only.
+#
+# What it does:
+#   1. Ensures wlan0 is managed by NetworkManager.
+#   2. Creates (or recreates) the "ShelfAware_Setup" AP hotspot profile.
+#
+# Usage:
+#   sudo bash shelfaware_network_setup.sh
+# =============================================================================
+
+set -euo pipefail
+
+AP_PROFILE="ShelfAware_Setup"
+AP_SSID="ShelfAware_Setup"
+AP_PASSWORD="shelfaware123"   # ← change before shipping product
+AP_IP="192.168.4.1/24"
+IFACE="wlan0"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+fatal() { echo -e "${RED}[FATAL]${NC} $*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || fatal "Must be run as root (sudo)."
+
+info "Ensuring NetworkManager manages $IFACE …"
+nmcli device set "$IFACE" managed yes \
+    || warn "Could not set $IFACE managed (may already be managed)."
+
+if nmcli connection show "$AP_PROFILE" &>/dev/null; then
+    warn "Profile '$AP_PROFILE' already exists – removing and recreating."
+    nmcli connection delete "$AP_PROFILE"
+fi
+
+info "Creating AP hotspot profile: $AP_PROFILE …"
+nmcli connection add \
+    type wifi \
+    ifname "$IFACE" \
+    con-name "$AP_PROFILE" \
+    autoconnect no \
+    ssid "$AP_SSID" \
+    -- \
+    wifi.mode ap \
+    wifi-sec.key-mgmt wpa-psk \
+    wifi-sec.psk "$AP_PASSWORD" \
+    ipv4.method shared \
+    ipv4.addresses "$AP_IP" \
+    ipv6.method disabled
+
+info "AP profile created successfully."
+nmcli connection show "$AP_PROFILE"
+
+info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+info "Provisioning complete."
+info ""
+info "To test AP manually (⚠️  will drop Tailscale):"
+info "  sudo nmcli connection up '$AP_PROFILE'"
+info ""
+info "To restore STA / Tailscale access:"
+info "  sudo nmcli connection down '$AP_PROFILE'"
+info "  sudo nmcli connection up <your-wifi-profile>"
+info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+

--- a/orchestration/wifi_connector.py
+++ b/orchestration/wifi_connector.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+wifi_connector.py  –  ShelfAware WiFi Credential Manager
+═════════════════════════════════════════════════════════
+Called by Process C (the setup web server) when the user submits
+their WiFi credentials via the captive portal.
+
+DEV_MODE  (SHELFAWARE_DEV=1):
+  All nmcli calls are short-circuited. apply_wifi_credentials()
+  logs its intended action and returns ConnectResult.SUCCESS.
+  rollback_to_ap() logs and returns True without touching NM.
+  Safe to run over Tailscale / mobile hotspot during development.
+
+Defensive contract:
+  • Attempts STA connection within CONNECT_TIMEOUT seconds.
+  • If not confirmed at L3 within that window → auto-rollback to AP.
+  • Thread-safe: module-level lock prevents overlapping apply() calls.
+  • rollback_to_ap() is idempotent and callable from any thread.
+"""
+
+import logging
+import os
+import subprocess
+import threading
+import time
+from enum import Enum, auto
+from typing import Optional
+
+log = logging.getLogger("shelfaware.wifi_connector")
+
+# ──────────────────────────────────────────────
+# DEV MODE  –  set SHELFAWARE_DEV=1 to activate
+# ──────────────────────────────────────────────
+DEV_MODE = os.environ.get("SHELFAWARE_DEV", "0") == "1"
+
+# ──────────────────────────────────────────────
+# Configuration
+# ──────────────────────────────────────────────
+AP_PROFILE_NAME  = "ShelfAware_Setup"
+STA_PROFILE_NAME = "ShelfAware_STA"
+IFACE            = "wlan0"
+CONNECT_TIMEOUT  = 60
+VERIFY_POLL_SEC  = 3
+NM_CMD_TIMEOUT   = 15
+
+_apply_lock = threading.Lock()
+
+
+class ConnectResult(Enum):
+    SUCCESS = auto()
+    TIMEOUT = auto()   # bad password / SSID not found → rolled back to AP
+    ERROR   = auto()   # unexpected failure
+
+
+# ──────────────────────────────────────────────
+# Low-level nmcli helpers
+# ──────────────────────────────────────────────
+
+def _nmcli(*args: str, timeout: int = NM_CMD_TIMEOUT) -> subprocess.CompletedProcess:
+    cmd = ["nmcli"] + list(args)
+    log.debug("nmcli: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if result.returncode != 0:
+        log.warning("nmcli (rc=%d): %s", result.returncode, result.stderr.strip())
+    return result
+
+
+def _connection_exists(profile: str) -> bool:
+    r = _nmcli("connection", "show", profile)
+    return r.returncode == 0
+
+
+def _is_connected_to_sta() -> bool:
+    """Returns True if wlan0 is fully connected on the STA profile."""
+    r = _nmcli("--terse", "--fields", "DEVICE,STATE,CONNECTION", "device", "status")
+    for line in r.stdout.splitlines():
+        parts = line.split(":")
+        if len(parts) >= 3 and parts[0] == IFACE:
+            if parts[1].lower() == "connected" and parts[2] == STA_PROFILE_NAME:
+                return True
+    return False
+
+
+def _create_or_update_sta_profile(ssid: str, password: str) -> bool:
+    if _connection_exists(STA_PROFILE_NAME):
+        log.info("Removing stale STA profile …")
+        _nmcli("connection", "delete", STA_PROFILE_NAME)
+
+    log.info("Creating STA profile for SSID '%s' …", ssid)
+    r = _nmcli(
+        "connection", "add",
+        "type",        "wifi",
+        "ifname",      IFACE,
+        "con-name",    STA_PROFILE_NAME,
+        "autoconnect", "yes",
+        "ssid",        ssid,
+        "--",
+        "wifi-sec.key-mgmt", "wpa-psk",
+        "wifi-sec.psk",      password,
+        "ipv4.method",       "auto",
+        "ipv6.method",       "disabled",
+        timeout=NM_CMD_TIMEOUT,
+    )
+    return r.returncode == 0
+
+
+def _activate_sta_profile() -> bool:
+    log.info("Activating STA profile …")
+    try:
+        _nmcli("connection", "down", AP_PROFILE_NAME)
+    except Exception:
+        pass
+
+    r = _nmcli(
+        "--timeout", str(CONNECT_TIMEOUT),
+        "connection", "up", STA_PROFILE_NAME,
+        timeout=CONNECT_TIMEOUT + 5,
+    )
+    return r.returncode == 0
+
+
+# ──────────────────────────────────────────────
+# Public API
+# ──────────────────────────────────────────────
+
+def rollback_to_ap() -> bool:
+    """
+    Tear down STA and restore the AP hotspot.
+    Idempotent. Safe to call from any thread.
+    """
+    if DEV_MODE:
+        log.info(
+            "[DEV MODE] Skipping AP rollback — would run: "
+            "nmcli connection down '%s' && nmcli connection up '%s'. "
+            "Returning True.", STA_PROFILE_NAME, AP_PROFILE_NAME
+        )
+        return True
+
+    log.warning("ROLLBACK: reverting to AP mode …")
+
+    try:
+        _nmcli("connection", "down", STA_PROFILE_NAME)
+    except Exception:
+        pass
+
+    try:
+        r = _nmcli("connection", "up", AP_PROFILE_NAME, timeout=20)
+        if r.returncode == 0:
+            log.info("ROLLBACK: AP mode restored successfully.")
+            return True
+        log.error("ROLLBACK: nmcli returned non-zero bringing up AP.")
+    except subprocess.TimeoutExpired:
+        log.error("ROLLBACK: timed out activating AP profile.")
+    except Exception as exc:
+        log.error("ROLLBACK: unexpected error: %s", exc, exc_info=True)
+
+    return False
+
+
+def apply_wifi_credentials(
+    ssid: str,
+    password: str,
+    timeout: int = CONNECT_TIMEOUT,
+) -> ConnectResult:
+    """
+    Thread-safe entry point for Process C.
+
+    In DEV_MODE: logs the intended action, returns SUCCESS immediately.
+    In production: creates STA profile, activates it, polls for L3
+    confirmation, rolls back to AP if not confirmed within `timeout`.
+    """
+    if not ssid or not password:
+        log.error("apply_wifi_credentials: ssid and password must be non-empty.")
+        return ConnectResult.ERROR
+
+    if DEV_MODE:
+        log.info(
+            "[DEV MODE] Skipping real WiFi connect — would attempt to join "
+            "SSID '%s' and roll back to '%s' on failure. Returning SUCCESS.",
+            ssid, AP_PROFILE_NAME,
+        )
+        return ConnectResult.SUCCESS
+
+    with _apply_lock:
+        log.info("Applying WiFi credentials for SSID '%s' …", ssid)
+        t_start = time.monotonic()
+
+        try:
+            if not _create_or_update_sta_profile(ssid, password):
+                log.error("Failed to create STA profile.")
+                rollback_to_ap()
+                return ConnectResult.ERROR
+        except Exception as exc:
+            log.error("STA profile creation exception: %s", exc, exc_info=True)
+            rollback_to_ap()
+            return ConnectResult.ERROR
+
+        try:
+            activated = _activate_sta_profile()
+        except subprocess.TimeoutExpired:
+            log.warning("nmcli connect timed out – rolling back.")
+            rollback_to_ap()
+            return ConnectResult.TIMEOUT
+        except Exception as exc:
+            log.error("STA activation exception: %s", exc, exc_info=True)
+            rollback_to_ap()
+            return ConnectResult.ERROR
+
+        if not activated:
+            log.warning("nmcli returned non-zero on connect – rolling back.")
+            rollback_to_ap()
+            return ConnectResult.TIMEOUT
+
+        log.info("Verifying L3 connectivity (polling for up to %d s) …", timeout)
+        deadline = t_start + timeout
+
+        while time.monotonic() < deadline:
+            if _is_connected_to_sta():
+                elapsed = time.monotonic() - t_start
+                log.info("Connected to '%s' in %.1f s.", ssid, elapsed)
+                return ConnectResult.SUCCESS
+            log.debug("Not yet connected. %.0f s remaining …",
+                      deadline - time.monotonic())
+            time.sleep(VERIFY_POLL_SEC)
+
+        log.warning(
+            "Could not verify connection to '%s' within %d s – rolling back.",
+            ssid, timeout,
+        )
+        rollback_to_ap()
+        return ConnectResult.TIMEOUT
+
+
+# ──────────────────────────────────────────────
+# CLI smoke-test
+# ──────────────────────────────────────────────
+if __name__ == "__main__":
+    import sys
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s  %(levelname)-8s  %(message)s",
+    )
+
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <SSID> <password>")
+        print(f"       SHELFAWARE_DEV=1 {sys.argv[0]} <SSID> <password>  (safe/mock)")
+        sys.exit(1)
+
+    result = apply_wifi_credentials(sys.argv[1], sys.argv[2])
+    print(f"\nResult: {result.name}")
+    sys.exit(0 if result == ConnectResult.SUCCESS else 1)

--- a/process-a/process_A.py
+++ b/process-a/process_A.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-process_a.py  –  SmartShelf Sensor Reader  (Dual-Zone Edition)
+process_A.py  –  ShelfAware Sensor Reader  (Dual-Zone Edition)
 ==============================================================
 Zone 1: ADC 0x48  →  Channels 0, 1, 2  →  scale_index 0, 1, 2
 Zone 2: ADC 0x49  →  Channels 0, 1, 2  →  scale_index 3, 4, 5
@@ -8,6 +8,15 @@ Zone 2: ADC 0x49  →  Channels 0, 1, 2  →  scale_index 3, 4, 5
 Backend contract (IMMUTABLE):
   scale_index is the position in SENSOR_SEQUENCE.
   Reordering SENSOR_SEQUENCE breaks Process B.  Do not reorder.
+
+Polling strategy (Delta-Based Activity Trigger):
+  ACTIVE  – a sensor delta > change_threshold_g was detected within
+            the last active_cooldown_s seconds. Poll at interval_active.
+  IDLE    – no significant delta detected recently. Poll at interval_idle.
+            Still reads all sensors for drift compensation, just less often.
+
+  A shelf with 5kg sitting still is IDLE.
+  A shelf where a user is adding/removing items is ACTIVE.
 
 Fault model:
   • If an entire ADC is missing at boot (e.g. 0x49 wire loose), that
@@ -27,7 +36,7 @@ import os
 import socket
 import time
 from collections import deque
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
 from typing import Dict, Optional
@@ -47,7 +56,7 @@ def _build_logger() -> logging.Logger:
         datefmt="%Y-%m-%dT%H:%M:%S",
     )
     handler = RotatingFileHandler(
-        "/var/log/smartshelf_process_a.log",
+        "/var/log/shelfaware_process_a.log",
         maxBytes=5 * 1024 * 1024,
         backupCount=3,
     )
@@ -55,7 +64,7 @@ def _build_logger() -> logging.Logger:
     console = logging.StreamHandler()
     console.setFormatter(fmt)
 
-    log = logging.getLogger("process_a")
+    log = logging.getLogger("shelfaware.process_a")
     log.setLevel(logging.DEBUG)
     log.addHandler(handler)
     log.addHandler(console)
@@ -86,11 +95,18 @@ class SystemConfig:
     window_size:         int   = 5
     drift_margin:        float = 0.15
     near_zero_threshold: int   = 300
-    interval_active:     float = 0.5
-    interval_idle:       float = 3.0
     storage_path:        str   = "baselines.json"
-    # How many consecutive read errors before we mark a channel faulted
     fault_threshold:     int   = 5
+
+    # ── Delta-Based Activity Trigger ──────────────────────────────────────────
+    # Fast polling rate when user interaction is detected
+    interval_active:     float = 0.5
+    # Slow polling rate when shelf is mechanically idle (items just resting)
+    interval_idle:       float = 10.0
+    # How long (seconds) to stay in ACTIVE mode after the last detected delta
+    active_cooldown_s:   float = 10.0
+    # Minimum gram change required to count as user interaction (filters drift)
+    change_threshold_g:  float = 15.0
 
 
 CONFIG = SystemConfig()
@@ -144,9 +160,9 @@ class HardwareManager:
     so the rest of the system degrades gracefully.
     """
 
-    _i2c: Optional[busio.I2C]          = None
+    _i2c: Optional[busio.I2C]              = None
     _ads_instances: Dict[int, ADS.ADS1115] = {}
-    _faulted_addresses: set            = set()
+    _faulted_addresses: set                = set()
 
     @classmethod
     def _ensure_i2c(cls) -> None:
@@ -156,10 +172,6 @@ class HardwareManager:
 
     @classmethod
     def get_adc_channel(cls, address: int, channel_index: int) -> Optional[AnalogIn]:
-        """
-        Returns an AnalogIn channel, or None if the ADC at `address` is faulted.
-        Raises exceptions for I2C bus-level failures (caller handles them).
-        """
         if address in cls._faulted_addresses:
             return None
 
@@ -186,6 +198,7 @@ class HardwareManager:
     def is_address_faulted(cls, address: int) -> bool:
         return address in cls._faulted_addresses
 
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Signal processing
 # ──────────────────────────────────────────────────────────────────────────────
@@ -206,7 +219,7 @@ class MovingAverage:
 class PersistentDriftCompensator:
     """
     Loads and saves per-sensor baselines to disk so zero-point drift
-    survives reboots.
+    survives reboots.  DO NOT MODIFY – untouched per spec.
     """
 
     def __init__(self, sensor_id: str):
@@ -261,22 +274,17 @@ def adc_to_grams(adc: float, cfg: SensorConfig) -> float:
         return 0.0
     return (adc / cfg.a_const) ** (1.0 / cfg.b_const)
 
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Per-sensor fault tracker
 # ──────────────────────────────────────────────────────────────────────────────
 
 class SensorFaultTracker:
-    """
-    Counts consecutive read errors per sensor.
-    Once `threshold` is reached, the sensor is marked faulted and
-    logged at ERROR level (not every single cycle).
-    """
-
     def __init__(self, sensor_id: str, threshold: int = CONFIG.fault_threshold):
-        self.sensor_id        = sensor_id
-        self.threshold        = threshold
-        self._consecutive     = 0
-        self._is_faulted      = False
+        self.sensor_id    = sensor_id
+        self.threshold    = threshold
+        self._consecutive = 0
+        self._is_faulted  = False
 
     def record_success(self) -> None:
         if self._is_faulted:
@@ -288,19 +296,18 @@ class SensorFaultTracker:
         self._consecutive += 1
         if self._consecutive >= self.threshold and not self._is_faulted:
             log.error(
-                "Sensor %s faulted after %d consecutive errors. "
-                "Last error: %s",
+                "Sensor %s faulted after %d consecutive errors. Last: %s",
                 self.sensor_id, self._consecutive, exc,
             )
             self._is_faulted = True
         elif not self._is_faulted:
             log.warning("Sensor %s read error (%d/%d): %s",
-                        self.sensor_id, self._consecutive,
-                        self.threshold, exc)
+                        self.sensor_id, self._consecutive, self.threshold, exc)
 
     @property
     def is_faulted(self) -> bool:
         return self._is_faulted
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Main loop
@@ -310,21 +317,26 @@ def main() -> None:
     log.info("=" * 60)
     log.info("PROCESS A STARTING  |  SHELF: %s", CONFIG.shelf_id)
     log.info("Sensor sequence (scale_index order): %s", SENSOR_SEQUENCE)
+    log.info(
+        "Delta-based polling | active=%.1fs  idle=%.1fs  "
+        "cooldown=%.1fs  threshold=%.1fg",
+        CONFIG.interval_active, CONFIG.interval_idle,
+        CONFIG.active_cooldown_s, CONFIG.change_threshold_g,
+    )
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
     # ── Initialise per-sensor objects ─────────────────────────────────────────
-    filters:      Dict[str, MovingAverage]          = {}
-    compensators: Dict[str, PersistentDriftCompensator] = {}
-    fault_trackers: Dict[str, SensorFaultTracker]   = {}
-    channels:     Dict[str, Optional[AnalogIn]]     = {}
+    filters:        Dict[str, MovingAverage]              = {}
+    compensators:   Dict[str, PersistentDriftCompensator] = {}
+    fault_trackers: Dict[str, SensorFaultTracker]         = {}
+    channels:       Dict[str, Optional[AnalogIn]]         = {}
 
     for s_id, cfg in SENSOR_MAP.items():
-        filters[s_id]       = MovingAverage(CONFIG.window_size)
-        compensators[s_id]  = PersistentDriftCompensator(s_id)
+        filters[s_id]        = MovingAverage(CONFIG.window_size)
+        compensators[s_id]   = PersistentDriftCompensator(s_id)
         fault_trackers[s_id] = SensorFaultTracker(s_id)
-        # Channel init: failure here only faults this ADC, not the process
-        channels[s_id] = HardwareManager.get_adc_channel(
+        channels[s_id]       = HardwareManager.get_adc_channel(
             cfg.adc_address, cfg.adc_channel
         )
         status = "OK" if channels[s_id] is not None else "FAULTED (ADC init failed)"
@@ -333,17 +345,32 @@ def main() -> None:
 
     log.info("Initialisation complete. Entering read loop.")
 
+    # ── Delta-Based Activity State ─────────────────────────────────────────────
+    # Tracks the last confirmed gram reading per sensor.
+    # Initialised to 0.0 — first cycle will always compute a delta from zero,
+    # but only triggers ACTIVE if that delta exceeds change_threshold_g.
+    previous_grams: Dict[str, float] = {s: 0.0 for s in SENSOR_SEQUENCE}
+
+    # Timestamp of the last sensor delta that exceeded change_threshold_g.
+    # Initialised to 0.0 so the system starts in IDLE mode on boot.
+    last_activity_ts: float = 0.0
+
     # ── Read loop ─────────────────────────────────────────────────────────────
     while True:
-        timestamp          = datetime.now(timezone.utc).isoformat()
-        any_weight_detected = False
+        timestamp = datetime.now(timezone.utc).isoformat()
 
-        # enumerate(SENSOR_SEQUENCE) is the ONLY place scale_index is assigned.
+        # Determine current mode BEFORE processing this cycle's readings.
+        # This ensures the print statements reflect the mode that governed
+        # the sleep we just woke up from, which is what Furkan wants to see.
+        is_active = (time.time() - last_activity_ts) < CONFIG.active_cooldown_s
+        mode_label = "ACTIVE" if is_active else "IDLE  "
+
         for scale_index, s_id in enumerate(SENSOR_SEQUENCE):
             cfg     = SENSOR_MAP[s_id]
             channel = channels[s_id]
+            zone    = "Z1" if cfg.adc_address == 0x48 else "Z2"
 
-            # ── ADC-level fault: entire chip is down ──────────────────────────
+            # ── ADC-level fault ───────────────────────────────────────────────
             if channel is None or HardwareManager.is_address_faulted(cfg.adc_address):
                 payload = {
                     "est_grams":   None,
@@ -371,14 +398,28 @@ def main() -> None:
 
                 fault_trackers[s_id].record_success()
 
-                if grams > 10.0:
-                    any_weight_detected = True
+                # ── Delta-Based Activity Trigger ──────────────────────────────
+                delta = abs(grams - previous_grams[s_id])
 
-                # Terminal diagnostic line
-                zone = "Z1" if cfg.adc_address == 0x48 else "Z2"
+                if delta > CONFIG.change_threshold_g:
+                    # Significant change detected — user is interacting.
+                    # Reset the cooldown clock.
+                    last_activity_ts = time.time()
+                    log.debug(
+                        "[%s] Activity detected: delta=%.1fg "
+                        "(%.1f → %.1f). Cooldown reset.",
+                        s_id, delta, previous_grams[s_id], grams,
+                    )
+
+                # Update previous reading for next cycle's delta calculation
+                previous_grams[s_id] = grams
+                # ── End Delta Logic ───────────────────────────────────────────
+
+                # Terminal diagnostic — mode label visible for Furkan's testing
                 print(
-                    f"[{s_id}({zone}|idx={scale_index})] "
-                    f"ADC:{raw_val:5}  Corr:{corrected:7.1f}  g:{grams:7.2f}"
+                    f"[{mode_label}] [{s_id}({zone}|idx={scale_index})] "
+                    f"ADC:{raw_val:5}  Corr:{corrected:7.1f}  "
+                    f"g:{grams:7.2f}  Δ:{delta:6.1f}g"
                 )
 
                 payload = {
@@ -395,8 +436,6 @@ def main() -> None:
 
             except Exception as exc:
                 fault_trackers[s_id].record_failure(exc)
-                # Send a fault payload so Process B doesn't stall waiting
-                # for a reading that will never arrive this cycle
                 payload = {
                     "est_grams":   None,
                     "shelf_id":    CONFIG.shelf_id,
@@ -410,9 +449,16 @@ def main() -> None:
                     (CONFIG.udp_ip, CONFIG.udp_port),
                 )
 
-        time.sleep(
-            CONFIG.interval_active if any_weight_detected else CONFIG.interval_idle
-        )
+        # ── Dynamic Sleep ─────────────────────────────────────────────────────
+        # Re-evaluate is_active after processing all sensors this cycle,
+        # in case a delta was detected mid-loop that should affect sleep now.
+        is_active = (time.time() - last_activity_ts) < CONFIG.active_cooldown_s
+        sleep_duration = CONFIG.interval_active if is_active else CONFIG.interval_idle
+
+        log.debug("Cycle complete. Mode: %s. Sleeping %.1fs.",
+                  "ACTIVE" if is_active else "IDLE", sleep_duration)
+
+        time.sleep(sleep_duration)
 
 
 if __name__ == "__main__":

--- a/process-a/process_A.py
+++ b/process-a/process_A.py
@@ -10,35 +10,43 @@ Backend contract (IMMUTABLE):
   Reordering SENSOR_SEQUENCE breaks Process B.  Do not reorder.
 
 Polling strategy (Delta-Based Activity Trigger):
-  ACTIVE  – a sensor delta > change_threshold_g was detected within
+  ACTIVE  - a sensor delta > change_threshold_g was detected within
             the last active_cooldown_s seconds. Poll at interval_active.
-  IDLE    – no significant delta detected recently. Poll at interval_idle.
-            Still reads all sensors for drift compensation, just less often.
+  IDLE    - no significant delta detected recently. Poll at interval_idle.
 
-  A shelf with 5kg sitting still is IDLE.
-  A shelf where a user is adding/removing items is ACTIVE.
+CPU governor strategy:
+  ACTIVE -> "performance"  (locks CPU to max 1500MHz)
+  IDLE   -> "ondemand"     (CPU scales naturally with load)
+
+  "ondemand" chosen over "powersave" to protect WiFi throughput.
+  The WiFi chip (CYW43455) is on a separate clock domain and is never
+  affected by cpufreq, but CPU starvation at 600MHz could cause UDP
+  processing latency in Process B. "ondemand" avoids this entirely.
+
+  Governor writes require root OR the following sudoers rule:
+    group2 ALL=(ALL) NOPASSWD: /usr/bin/tee /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+  In production (systemd, runs as root) sudo is bypassed automatically.
+  If neither condition is met, a warning is logged and the process
+  continues normally - governor management is non-critical.
 
 Fault model:
-  • If an entire ADC is missing at boot (e.g. 0x49 wire loose), that
-    chip is marked FAULTED and its three channels emit null payloads
-    with an "adc_fault" flag every cycle so Process B can distinguish
-    "sensor reads zero" from "sensor is dead".
-  • If a single read fails mid-run, the error is logged and that
-    sample is skipped; the loop continues for all other sensors.
-  • If the I2C bus itself dies, the exception propagates to main()
-    which logs it and exits cleanly (letting systemd/orchestrator
-    decide whether to restart).
+  If an entire ADC is missing at boot, it is marked FAULTED and its
+  channels emit null payloads with adc_fault=True every cycle.
+  Single read failures are logged and skipped; loop continues.
+  I2C bus death propagates to main() for orchestrator to handle.
 """
 
 import json
 import logging
 import os
 import socket
+import subprocess
 import time
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
+from pathlib import Path
 from typing import Dict, Optional
 
 import board
@@ -46,9 +54,9 @@ import busio
 import adafruit_ads1x15.ads1115 as ADS
 from adafruit_ads1x15.analog_in import AnalogIn
 
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
 # Logging
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
 
 def _build_logger() -> logging.Logger:
     fmt = logging.Formatter(
@@ -63,7 +71,6 @@ def _build_logger() -> logging.Logger:
     handler.setFormatter(fmt)
     console = logging.StreamHandler()
     console.setFormatter(fmt)
-
     log = logging.getLogger("shelfaware.process_a")
     log.setLevel(logging.DEBUG)
     log.addHandler(handler)
@@ -73,9 +80,9 @@ def _build_logger() -> logging.Logger:
 
 log = _build_logger()
 
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
 # Configuration
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
 
 @dataclass
 class SensorConfig:
@@ -97,38 +104,31 @@ class SystemConfig:
     near_zero_threshold: int   = 300
     storage_path:        str   = "baselines.json"
     fault_threshold:     int   = 5
-
-    # ── Delta-Based Activity Trigger ──────────────────────────────────────────
-    # Fast polling rate when user interaction is detected
+    # Delta-Based Activity Trigger
     interval_active:     float = 0.5
-    # Slow polling rate when shelf is mechanically idle (items just resting)
     interval_idle:       float = 10.0
-    # How long (seconds) to stay in ACTIVE mode after the last detected delta
     active_cooldown_s:   float = 10.0
-    # Minimum gram change required to count as user interaction (filters drift)
     change_threshold_g:  float = 15.0
+    # CPU Governor
+    governor_active:     str   = "performance"
+    governor_idle:       str   = "ondemand"
 
 
 CONFIG = SystemConfig()
 
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
 # Sensor map  (insertion order is the scale_index contract)
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
 
 SENSOR_MAP: Dict[str, SensorConfig] = {
-    # ── Zone 1  –  ADC 0x48  –  scale_index 0, 1, 2 ─────────────────────────
     "Z1_A0": SensorConfig(adc_channel=0, adc_address=0x48),
     "Z1_A1": SensorConfig(adc_channel=1, adc_address=0x48),
     "Z1_A2": SensorConfig(adc_channel=2, adc_address=0x48),
-    # ── Zone 2  –  ADC 0x49  –  scale_index 3, 4, 5 ─────────────────────────
     "Z2_A0": SensorConfig(adc_channel=0, adc_address=0x49),
     "Z2_A1": SensorConfig(adc_channel=1, adc_address=0x49),
     "Z2_A2": SensorConfig(adc_channel=2, adc_address=0x49),
 }
 
-# Explicit ordered sequence – this is the SINGLE source of truth for
-# scale_index assignment.  enumerate(SENSOR_SEQUENCE) → (scale_index, s_id).
-# Never derive this from dict.keys() alone; be explicit.
 SENSOR_SEQUENCE = [
     "Z1_A0",  # scale_index 0
     "Z1_A1",  # scale_index 1
@@ -138,28 +138,133 @@ SENSOR_SEQUENCE = [
     "Z2_A2",  # scale_index 5
 ]
 
-# Validate at import time – catches typos before the Pi boots
-assert set(SENSOR_SEQUENCE) == set(SENSOR_MAP.keys()), (
-    "SENSOR_SEQUENCE and SENSOR_MAP are out of sync. "
-    "Every sensor must appear in both, exactly once."
-)
-assert len(SENSOR_SEQUENCE) == len(set(SENSOR_SEQUENCE)), (
+assert set(SENSOR_SEQUENCE) == set(SENSOR_MAP.keys()), \
+    "SENSOR_SEQUENCE and SENSOR_MAP are out of sync."
+assert len(SENSOR_SEQUENCE) == len(set(SENSOR_SEQUENCE)), \
     "SENSOR_SEQUENCE contains duplicates."
-)
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Hardware manager  (handles multiple I2C addresses)
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
+# CPU Governor Manager
+# ------------------------------------------------------------------------------
+
+class CpuGovernor:
+    """
+    Manages the Linux cpufreq governor in sync with the shelf activity state.
+
+    Write strategy (tried in order until one succeeds):
+      1. Direct sysfs write  - works when running as root (production/systemd).
+      2. sudo tee            - works in dev when the sudoers rule is in place.
+      3. Disabled            - logs a warning once and never tries again.
+
+    Only writes to sysfs when the governor actually needs to change,
+    avoiding redundant kernel calls every cycle.
+    """
+
+    GOVERNOR_PATH  = Path("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor")
+    AVAILABLE_PATH = Path("/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors")
+
+    def __init__(self, governor_active: str, governor_idle: str):
+        self._governor_active   = governor_active
+        self._governor_idle     = governor_idle
+        self._current_governor: Optional[str] = None
+        self._enabled           = self._check_available()
+
+    def _check_available(self) -> bool:
+        if not self.GOVERNOR_PATH.exists():
+            log.warning(
+                "CpuGovernor: sysfs path not found (%s). "
+                "CPU frequency management disabled.", self.GOVERNOR_PATH,
+            )
+            return False
+        try:
+            available = self.AVAILABLE_PATH.read_text().split()
+            for gov in (self._governor_active, self._governor_idle):
+                if gov not in available:
+                    log.warning(
+                        "CpuGovernor: governor '%s' not available. "
+                        "Available: %s. CPU frequency management disabled.",
+                        gov, available,
+                    )
+                    return False
+        except Exception as exc:
+            log.warning("CpuGovernor: could not read available governors: %s", exc)
+            return False
+
+        log.info("CpuGovernor: initialised. active='%s'  idle='%s'",
+                 self._governor_active, self._governor_idle)
+        return True
+
+    def _write_governor(self, governor: str) -> bool:
+        # Strategy 1: direct write (root / production)
+        try:
+            self.GOVERNOR_PATH.write_text(governor)
+            return True
+        except PermissionError:
+            pass
+        except Exception as exc:
+            log.warning("CpuGovernor: direct write failed: %s", exc)
+            return False
+
+        # Strategy 2: sudo tee (dev with sudoers rule)
+        try:
+            result = subprocess.run(
+                ["sudo", "tee", str(self.GOVERNOR_PATH)],
+                input=governor,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                return True
+            log.warning("CpuGovernor: sudo tee failed (rc=%d): %s",
+                        result.returncode, result.stderr.strip())
+        except subprocess.TimeoutExpired:
+            log.warning("CpuGovernor: sudo tee timed out.")
+        except Exception as exc:
+            log.warning("CpuGovernor: sudo tee error: %s", exc)
+
+        return False
+
+    def set(self, is_active: bool) -> None:
+        """
+        Call once per cycle with the current activity state.
+        No-ops if governor is already correct.
+        """
+        if not self._enabled:
+            return
+
+        target = self._governor_active if is_active else self._governor_idle
+
+        if target == self._current_governor:
+            return
+
+        if self._write_governor(target):
+            log.info("CpuGovernor: %s -> %s",
+                     self._current_governor or "unknown", target)
+            self._current_governor = target
+        else:
+            log.error(
+                "CpuGovernor: could not write governor '%s'. "
+                "Check sudoers rule or run as root. Disabling for this session.",
+                target,
+            )
+            self._enabled = False
+
+    def restore_default(self) -> None:
+        """Restore 'ondemand' on clean exit."""
+        if not self._enabled:
+            return
+        if self._write_governor("ondemand"):
+            log.info("CpuGovernor: restored to 'ondemand' on exit.")
+        else:
+            log.warning("CpuGovernor: could not restore governor on exit.")
+
+
+# ------------------------------------------------------------------------------
+# Hardware manager
+# ------------------------------------------------------------------------------
 
 class HardwareManager:
-    """
-    Singleton-style I2C / ADC factory.
-
-    One shared I2C bus.  One ADS1115 instance per unique address.
-    Addresses that fail to initialise are placed in _faulted_addresses
-    so the rest of the system degrades gracefully.
-    """
-
     _i2c: Optional[busio.I2C]              = None
     _ads_instances: Dict[int, ADS.ADS1115] = {}
     _faulted_addresses: set                = set()
@@ -174,24 +279,18 @@ class HardwareManager:
     def get_adc_channel(cls, address: int, channel_index: int) -> Optional[AnalogIn]:
         if address in cls._faulted_addresses:
             return None
-
         cls._ensure_i2c()
-
         if address not in cls._ads_instances:
             try:
-                cls._ads_instances[address] = ADS.ADS1115(
-                    cls._i2c, address=address
-                )
+                cls._ads_instances[address] = ADS.ADS1115(cls._i2c, address=address)
                 log.info("ADS1115 at 0x%02X initialised.", address)
             except Exception as exc:
                 log.error(
                     "Failed to initialise ADS1115 at 0x%02X: %s. "
-                    "All channels on this ADC will be marked faulted.",
-                    address, exc,
+                    "All channels on this ADC will be marked faulted.", address, exc,
                 )
                 cls._faulted_addresses.add(address)
                 return None
-
         return AnalogIn(cls._ads_instances[address], channel_index)
 
     @classmethod
@@ -199,9 +298,9 @@ class HardwareManager:
         return address in cls._faulted_addresses
 
 
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
 # Signal processing
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
 
 class MovingAverage:
     def __init__(self, size: int):
@@ -217,10 +316,7 @@ class MovingAverage:
 
 
 class PersistentDriftCompensator:
-    """
-    Loads and saves per-sensor baselines to disk so zero-point drift
-    survives reboots.  DO NOT MODIFY – untouched per spec.
-    """
+    """DO NOT MODIFY - untouched per spec."""
 
     def __init__(self, sensor_id: str):
         self.sensor_id = sensor_id
@@ -232,8 +328,7 @@ class PersistentDriftCompensator:
                 with open(CONFIG.storage_path, "r") as f:
                     return json.load(f).get(self.sensor_id)
             except Exception as exc:
-                log.warning("Could not load baseline for %s: %s",
-                            self.sensor_id, exc)
+                log.warning("Could not load baseline for %s: %s", self.sensor_id, exc)
         return None
 
     def _save_baseline(self, value: float) -> None:
@@ -257,15 +352,13 @@ class PersistentDriftCompensator:
             self._save_baseline(filtered_adc)
             log.info("Baseline captured for %s: %.1f", self.sensor_id, filtered_adc)
             return 0.0
-
         if filtered_adc <= CONFIG.near_zero_threshold:
             drift_delta = abs(filtered_adc - self._baseline)
             if (drift_delta / (self._baseline + 1)) > CONFIG.drift_margin:
-                log.debug("Drift corrected for %s: %.1f → %.1f",
+                log.debug("Drift corrected for %s: %.1f -> %.1f",
                           self.sensor_id, self._baseline, filtered_adc)
                 self._baseline = filtered_adc
                 self._save_baseline(filtered_adc)
-
         return max(0.0, filtered_adc - self._baseline)
 
 
@@ -275,9 +368,9 @@ def adc_to_grams(adc: float, cfg: SensorConfig) -> float:
     return (adc / cfg.a_const) ** (1.0 / cfg.b_const)
 
 
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
 # Per-sensor fault tracker
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
 
 class SensorFaultTracker:
     def __init__(self, sensor_id: str, threshold: int = CONFIG.fault_threshold):
@@ -295,10 +388,8 @@ class SensorFaultTracker:
     def record_failure(self, exc: Exception) -> None:
         self._consecutive += 1
         if self._consecutive >= self.threshold and not self._is_faulted:
-            log.error(
-                "Sensor %s faulted after %d consecutive errors. Last: %s",
-                self.sensor_id, self._consecutive, exc,
-            )
+            log.error("Sensor %s faulted after %d consecutive errors. Last: %s",
+                      self.sensor_id, self._consecutive, exc)
             self._is_faulted = True
         elif not self._is_faulted:
             log.warning("Sensor %s read error (%d/%d): %s",
@@ -309,9 +400,9 @@ class SensorFaultTracker:
         return self._is_faulted
 
 
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
 # Main loop
-# ──────────────────────────────────────────────────────────────────────────────
+# ------------------------------------------------------------------------------
 
 def main() -> None:
     log.info("=" * 60)
@@ -326,7 +417,10 @@ def main() -> None:
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-    # ── Initialise per-sensor objects ─────────────────────────────────────────
+    # CPU Governor - initialised once, used every cycle
+    cpu = CpuGovernor(CONFIG.governor_active, CONFIG.governor_idle)
+
+    # Per-sensor objects
     filters:        Dict[str, MovingAverage]              = {}
     compensators:   Dict[str, PersistentDriftCompensator] = {}
     fault_trackers: Dict[str, SensorFaultTracker]         = {}
@@ -340,37 +434,29 @@ def main() -> None:
             cfg.adc_address, cfg.adc_channel
         )
         status = "OK" if channels[s_id] is not None else "FAULTED (ADC init failed)"
-        log.info("Channel %s at 0x%02X ch%d → %s",
+        log.info("Channel %s at 0x%02X ch%d -> %s",
                  s_id, cfg.adc_address, cfg.adc_channel, status)
 
     log.info("Initialisation complete. Entering read loop.")
 
-    # ── Delta-Based Activity State ─────────────────────────────────────────────
-    # Tracks the last confirmed gram reading per sensor.
-    # Initialised to 0.0 — first cycle will always compute a delta from zero,
-    # but only triggers ACTIVE if that delta exceeds change_threshold_g.
-    previous_grams: Dict[str, float] = {s: 0.0 for s in SENSOR_SEQUENCE}
+    # Delta-Based Activity State
+    previous_grams:   Dict[str, float] = {s: 0.0 for s in SENSOR_SEQUENCE}
+    last_activity_ts: float            = 0.0
 
-    # Timestamp of the last sensor delta that exceeded change_threshold_g.
-    # Initialised to 0.0 so the system starts in IDLE mode on boot.
-    last_activity_ts: float = 0.0
-
-    # ── Read loop ─────────────────────────────────────────────────────────────
     while True:
-        timestamp = datetime.now(timezone.utc).isoformat()
-
-        # Determine current mode BEFORE processing this cycle's readings.
-        # This ensures the print statements reflect the mode that governed
-        # the sleep we just woke up from, which is what Furkan wants to see.
-        is_active = (time.time() - last_activity_ts) < CONFIG.active_cooldown_s
+        timestamp  = datetime.now(timezone.utc).isoformat()
+        is_active  = (time.time() - last_activity_ts) < CONFIG.active_cooldown_s
         mode_label = "ACTIVE" if is_active else "IDLE  "
+
+        # Apply governor at the START of each cycle
+        cpu.set(is_active)
 
         for scale_index, s_id in enumerate(SENSOR_SEQUENCE):
             cfg     = SENSOR_MAP[s_id]
             channel = channels[s_id]
             zone    = "Z1" if cfg.adc_address == 0x48 else "Z2"
 
-            # ── ADC-level fault ───────────────────────────────────────────────
+            # ADC-level fault
             if channel is None or HardwareManager.is_address_faulted(cfg.adc_address):
                 payload = {
                     "est_grams":   None,
@@ -380,15 +466,10 @@ def main() -> None:
                     "adc_fault":   True,
                     "sensor_id":   s_id,
                 }
-                sock.sendto(
-                    json.dumps(payload).encode(),
-                    (CONFIG.udp_ip, CONFIG.udp_port),
-                )
-                log.debug("[%s] scale_index=%d  ADC FAULTED – null payload sent.",
-                          s_id, scale_index)
+                sock.sendto(json.dumps(payload).encode(), (CONFIG.udp_ip, CONFIG.udp_port))
+                log.debug("[%s] scale_index=%d  ADC FAULTED.", s_id, scale_index)
                 continue
 
-            # ── Normal read path ──────────────────────────────────────────────
             try:
                 raw_val   = channel.value
                 clean     = 0 if raw_val < CONFIG.deadzone_adc else raw_val
@@ -398,28 +479,18 @@ def main() -> None:
 
                 fault_trackers[s_id].record_success()
 
-                # ── Delta-Based Activity Trigger ──────────────────────────────
+                # Delta-Based Activity Trigger
                 delta = abs(grams - previous_grams[s_id])
-
                 if delta > CONFIG.change_threshold_g:
-                    # Significant change detected — user is interacting.
-                    # Reset the cooldown clock.
                     last_activity_ts = time.time()
-                    log.debug(
-                        "[%s] Activity detected: delta=%.1fg "
-                        "(%.1f → %.1f). Cooldown reset.",
-                        s_id, delta, previous_grams[s_id], grams,
-                    )
-
-                # Update previous reading for next cycle's delta calculation
+                    log.debug("[%s] Activity: delta=%.1fg (%.1f->%.1f). Cooldown reset.",
+                              s_id, delta, previous_grams[s_id], grams)
                 previous_grams[s_id] = grams
-                # ── End Delta Logic ───────────────────────────────────────────
 
-                # Terminal diagnostic — mode label visible for Furkan's testing
                 print(
                     f"[{mode_label}] [{s_id}({zone}|idx={scale_index})] "
                     f"ADC:{raw_val:5}  Corr:{corrected:7.1f}  "
-                    f"g:{grams:7.2f}  Δ:{delta:6.1f}g"
+                    f"g:{grams:7.2f}  d:{delta:6.1f}g"
                 )
 
                 payload = {
@@ -429,10 +500,7 @@ def main() -> None:
                     "scale_index": scale_index,
                     "adc_fault":   False,
                 }
-                sock.sendto(
-                    json.dumps(payload).encode(),
-                    (CONFIG.udp_ip, CONFIG.udp_port),
-                )
+                sock.sendto(json.dumps(payload).encode(), (CONFIG.udp_ip, CONFIG.udp_port))
 
             except Exception as exc:
                 fault_trackers[s_id].record_failure(exc)
@@ -444,16 +512,14 @@ def main() -> None:
                     "adc_fault":   True,
                     "sensor_id":   s_id,
                 }
-                sock.sendto(
-                    json.dumps(payload).encode(),
-                    (CONFIG.udp_ip, CONFIG.udp_port),
-                )
+                sock.sendto(json.dumps(payload).encode(), (CONFIG.udp_ip, CONFIG.udp_port))
 
-        # ── Dynamic Sleep ─────────────────────────────────────────────────────
-        # Re-evaluate is_active after processing all sensors this cycle,
-        # in case a delta was detected mid-loop that should affect sleep now.
-        is_active = (time.time() - last_activity_ts) < CONFIG.active_cooldown_s
+        # Re-evaluate after full sweep — a delta mid-loop takes effect now
+        is_active      = (time.time() - last_activity_ts) < CONFIG.active_cooldown_s
         sleep_duration = CONFIG.interval_active if is_active else CONFIG.interval_idle
+
+        # Update governor if state flipped during the sweep
+        cpu.set(is_active)
 
         log.debug("Cycle complete. Mode: %s. Sleeping %.1fs.",
                   "ACTIVE" if is_active else "IDLE", sleep_duration)
@@ -469,3 +535,8 @@ if __name__ == "__main__":
     except Exception as exc:
         log.critical("Process A crashed: %s", exc, exc_info=True)
         raise
+    finally:
+        try:
+            CpuGovernor(CONFIG.governor_active, CONFIG.governor_idle).restore_default()
+        except Exception:
+            pass

--- a/process-a/process_A.py
+++ b/process-a/process_A.py
@@ -1,190 +1,425 @@
-import time
-import random
-import socket
-import json
-from collections import deque
-from datetime import datetime, timezone
+#!/usr/bin/env python3
+"""
+process_a.py  –  SmartShelf Sensor Reader  (Dual-Zone Edition)
+==============================================================
+Zone 1: ADC 0x48  →  Channels 0, 1, 2  →  scale_index 0, 1, 2
+Zone 2: ADC 0x49  →  Channels 0, 1, 2  →  scale_index 3, 4, 5
 
-import board, busio
+Backend contract (IMMUTABLE):
+  scale_index is the position in SENSOR_SEQUENCE.
+  Reordering SENSOR_SEQUENCE breaks Process B.  Do not reorder.
+
+Fault model:
+  • If an entire ADC is missing at boot (e.g. 0x49 wire loose), that
+    chip is marked FAULTED and its three channels emit null payloads
+    with an "adc_fault" flag every cycle so Process B can distinguish
+    "sensor reads zero" from "sensor is dead".
+  • If a single read fails mid-run, the error is logged and that
+    sample is skipped; the loop continues for all other sensors.
+  • If the I2C bus itself dies, the exception propagates to main()
+    which logs it and exits cleanly (letting systemd/orchestrator
+    decide whether to restart).
+"""
+
+import json
+import logging
+import os
+import socket
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
+from typing import Dict, Optional
+
+import board
+import busio
 import adafruit_ads1x15.ads1115 as ADS
 from adafruit_ads1x15.analog_in import AnalogIn
 
-# ------- CONFIG -------
-# UDP Configuration (Talking to Process B on the same machine)
-UDP_IP   = "127.0.0.1"
-UDP_PORT = 5005
-sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+# ──────────────────────────────────────────────────────────────────────────────
+# Logging
+# ──────────────────────────────────────────────────────────────────────────────
 
-SHELF_ID = "demo-shelf-001"
+def _build_logger() -> logging.Logger:
+    fmt = logging.Formatter(
+        "%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+    handler = RotatingFileHandler(
+        "/var/log/smartshelf_process_a.log",
+        maxBytes=5 * 1024 * 1024,
+        backupCount=3,
+    )
+    handler.setFormatter(fmt)
+    console = logging.StreamHandler()
+    console.setFormatter(fmt)
 
-# Calibration constants, Test 3 power curve: ADC = A * Weight^B
-A_CONSTANT = 14.56
-B_CONSTANT = 1.05
+    log = logging.getLogger("process_a")
+    log.setLevel(logging.DEBUG)
+    log.addHandler(handler)
+    log.addHandler(console)
+    return log
 
-DEADZONE_ADC         = 150
-WINDOW_SIZE          = 5
-DRIFT_MARGIN         = 0.15
-NEAR_ZERO_THRESHOLD  = DEADZONE_ADC * 2
 
-SAMPLE_INTERVAL_ACTIVE = 0.5  # seconds, when system is awake
-SAMPLE_INTERVAL_IDLE   = 3.0  # seconds, when system is sleeping
+log = _build_logger()
 
-# Full-weight reference per sensor (grams).
-# The backend sends this via the "Wake" ping.
-# Default to 1 000 g until a real value arrives.
-FULL_WEIGHT_G: dict[str, float] = {
-    "Z1_A0": 1000.0,
-    "Z1_A1": 1000.0,
-    "Z1_A2": 1000.0,
+# ──────────────────────────────────────────────────────────────────────────────
+# Configuration
+# ──────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class SensorConfig:
+    adc_channel:   int
+    adc_address:   int   = 0x48
+    a_const:       float = 14.56
+    b_const:       float = 1.05
+    full_weight_g: float = 1000.0
+
+
+@dataclass
+class SystemConfig:
+    shelf_id:            str   = "62d1eea1-6253-4157-a663-8f099eb3a9fe"
+    udp_ip:              str   = "127.0.0.1"
+    udp_port:            int   = 5005
+    deadzone_adc:        int   = 150
+    window_size:         int   = 5
+    drift_margin:        float = 0.15
+    near_zero_threshold: int   = 300
+    interval_active:     float = 0.5
+    interval_idle:       float = 3.0
+    storage_path:        str   = "baselines.json"
+    # How many consecutive read errors before we mark a channel faulted
+    fault_threshold:     int   = 5
+
+
+CONFIG = SystemConfig()
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Sensor map  (insertion order is the scale_index contract)
+# ──────────────────────────────────────────────────────────────────────────────
+
+SENSOR_MAP: Dict[str, SensorConfig] = {
+    # ── Zone 1  –  ADC 0x48  –  scale_index 0, 1, 2 ─────────────────────────
+    "Z1_A0": SensorConfig(adc_channel=0, adc_address=0x48),
+    "Z1_A1": SensorConfig(adc_channel=1, adc_address=0x48),
+    "Z1_A2": SensorConfig(adc_channel=2, adc_address=0x48),
+    # ── Zone 2  –  ADC 0x49  –  scale_index 3, 4, 5 ─────────────────────────
+    "Z2_A0": SensorConfig(adc_channel=0, adc_address=0x49),
+    "Z2_A1": SensorConfig(adc_channel=1, adc_address=0x49),
+    "Z2_A2": SensorConfig(adc_channel=2, adc_address=0x49),
 }
 
+# Explicit ordered sequence – this is the SINGLE source of truth for
+# scale_index assignment.  enumerate(SENSOR_SEQUENCE) → (scale_index, s_id).
+# Never derive this from dict.keys() alone; be explicit.
+SENSOR_SEQUENCE = [
+    "Z1_A0",  # scale_index 0
+    "Z1_A1",  # scale_index 1
+    "Z1_A2",  # scale_index 2
+    "Z2_A0",  # scale_index 3
+    "Z2_A1",  # scale_index 4
+    "Z2_A2",  # scale_index 5
+]
 
-# ------- STATE TABLE -------
+# Validate at import time – catches typos before the Pi boots
+assert set(SENSOR_SEQUENCE) == set(SENSOR_MAP.keys()), (
+    "SENSOR_SEQUENCE and SENSOR_MAP are out of sync. "
+    "Every sensor must appear in both, exactly once."
+)
+assert len(SENSOR_SEQUENCE) == len(set(SENSOR_SEQUENCE)), (
+    "SENSOR_SEQUENCE contains duplicates."
+)
 
-# Ratio = est_grams / full_weight_g
-# Each state has an ENTER threshold (ratio must rise TO here to enter)
-# and an EXIT threshold (ratio must fall BELOW here to leave).
+# ──────────────────────────────────────────────────────────────────────────────
+# Hardware manager  (handles multiple I2C addresses)
+# ──────────────────────────────────────────────────────────────────────────────
 
-# STATE_TABLE = [
-#     # (state,  enter_ratio, exit_ratio)
-#     (1.00,     0.85,        0.80),
-#     (0.75,     0.65,        0.60),
-#     (0.50,     0.40,        0.35),
-#     (0.33,     0.15,        0.10),
-#     (0.00,     0.00,        0.00),
-# ]
+class HardwareManager:
+    """
+    Singleton-style I2C / ADC factory.
 
-# MOCK ADC  (replace with real Adafruit ADS1x15 I2C driver)
-def read_adc1(sensor_id: str) -> int:
+    One shared I2C bus.  One ADS1115 instance per unique address.
+    Addresses that fail to initialise are placed in _faulted_addresses
+    so the rest of the system degrades gracefully.
+    """
 
-      i2c  = busio.I2C(board.SCL, board.SDA)
-      ads  = ADS.ADS1115(i2c, address=0x48)   # 0x49 for Zone 1 correct
-      chan = AnalogIn(ads, ADS.P0)             # P0/P1/P2 per pin
-      return chan.value
+    _i2c: Optional[busio.I2C]          = None
+    _ads_instances: Dict[int, ADS.ADS1115] = {}
+    _faulted_addresses: set            = set()
 
-def read_adc2(sensor_id: str) -> int:
-    i2c  = busio.I2C(board.SCL, board.SDA)
-    ads  = ADS.ADS1115(i2c, address=0x49)   # 0x49 for Zone 1 correct
-    chan = AnalogIn(ads, ADS.P0)             # P0/P1/P2 per pin
-    return chan.value
+    @classmethod
+    def _ensure_i2c(cls) -> None:
+        if cls._i2c is None:
+            cls._i2c = busio.I2C(board.SCL, board.SDA)
+            log.info("I2C bus initialised.")
 
+    @classmethod
+    def get_adc_channel(cls, address: int, channel_index: int) -> Optional[AnalogIn]:
+        """
+        Returns an AnalogIn channel, or None if the ADC at `address` is faulted.
+        Raises exceptions for I2C bus-level failures (caller handles them).
+        """
+        if address in cls._faulted_addresses:
+            return None
 
+        cls._ensure_i2c()
 
-#------- MOVING AVERAGE FILTER -------
+        if address not in cls._ads_instances:
+            try:
+                cls._ads_instances[address] = ADS.ADS1115(
+                    cls._i2c, address=address
+                )
+                log.info("ADS1115 at 0x%02X initialised.", address)
+            except Exception as exc:
+                log.error(
+                    "Failed to initialise ADS1115 at 0x%02X: %s. "
+                    "All channels on this ADC will be marked faulted.",
+                    address, exc,
+                )
+                cls._faulted_addresses.add(address)
+                return None
+
+        return AnalogIn(cls._ads_instances[address], channel_index)
+
+    @classmethod
+    def is_address_faulted(cls, address: int) -> bool:
+        return address in cls._faulted_addresses
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Signal processing
+# ──────────────────────────────────────────────────────────────────────────────
+
 class MovingAverage:
     def __init__(self, size: int):
-        self.buffer = deque(maxlen=size)
+        self.buffer      = deque(maxlen=size)
+        self.running_sum = 0.0
 
     def add(self, value: float) -> float:
+        if len(self.buffer) == self.buffer.maxlen:
+            self.running_sum -= self.buffer[0]
         self.buffer.append(value)
-        return sum(self.buffer) / len(self.buffer)
+        self.running_sum += value
+        return self.running_sum / len(self.buffer)
 
 
-# ------- CALIBRATION -------
-def adc_to_grams(adc: float) -> float:
-    if adc <= 0:
-        return 0.0
-    return (adc / A_CONSTANT) ** (1.0 / B_CONSTANT)
-
-
-# ------- CONDITIONAL AUTO-TARE -------
-class DriftCompensator:
+class PersistentDriftCompensator:
     """
-    Stores a per-sensor ADC baseline and re-zeroes it when the shelf appears empty AND the floor has drifted beyond DRIFT_MARGIN (15%).
-
-    Only re-tares during empty periods so a real load is never zeroed out.
+    Loads and saves per-sensor baselines to disk so zero-point drift
+    survives reboots.
     """
-    def __init__(self):
-        self._baseline: float | None = None
 
-    def correct(self, sensor_id: str, filtered_adc: float) -> float:
+    def __init__(self, sensor_id: str):
+        self.sensor_id = sensor_id
+        self._baseline: Optional[float] = self._load_baseline()
+
+    def _load_baseline(self) -> Optional[float]:
+        if os.path.exists(CONFIG.storage_path):
+            try:
+                with open(CONFIG.storage_path, "r") as f:
+                    return json.load(f).get(self.sensor_id)
+            except Exception as exc:
+                log.warning("Could not load baseline for %s: %s",
+                            self.sensor_id, exc)
+        return None
+
+    def _save_baseline(self, value: float) -> None:
+        data: dict = {}
+        if os.path.exists(CONFIG.storage_path):
+            try:
+                with open(CONFIG.storage_path, "r") as f:
+                    data = json.load(f)
+            except Exception as exc:
+                log.warning("Could not read baseline file before write: %s", exc)
+        data[self.sensor_id] = value
+        try:
+            with open(CONFIG.storage_path, "w") as f:
+                json.dump(data, f, indent=2)
+        except Exception as exc:
+            log.error("Could not save baseline for %s: %s", self.sensor_id, exc)
+
+    def correct(self, filtered_adc: float) -> float:
         if self._baseline is None:
             self._baseline = filtered_adc
-            return filtered_adc
+            self._save_baseline(filtered_adc)
+            log.info("Baseline captured for %s: %.1f", self.sensor_id, filtered_adc)
+            return 0.0
 
-        if filtered_adc <= NEAR_ZERO_THRESHOLD and self._baseline > 0:
-            drift = abs(filtered_adc - self._baseline) / self._baseline
-            if drift > DRIFT_MARGIN:
-                print(
-                    f"[Process A] ⚠  Drift on {sensor_id}: "
-                    f"{drift*100:.1f}% — re-zeroing baseline."
-                )
+        if filtered_adc <= CONFIG.near_zero_threshold:
+            drift_delta = abs(filtered_adc - self._baseline)
+            if (drift_delta / (self._baseline + 1)) > CONFIG.drift_margin:
+                log.debug("Drift corrected for %s: %.1f → %.1f",
+                          self.sensor_id, self._baseline, filtered_adc)
                 self._baseline = filtered_adc
+                self._save_baseline(filtered_adc)
 
         return max(0.0, filtered_adc - self._baseline)
 
 
-# # ------- STATE MACHINE -------
-# def determine_state(ratio: float, prev_state: float) -> float:
-#     """
-#     Walk STATE_TABLE from highest to lowest.
-#     - If already IN a state, stay until ratio drops below exit_ratio.
-#     - If NOT in a state, only enter when ratio rises above enter_ratio.
-#     """
-#     for state, enter_ratio, exit_ratio in STATE_TABLE:
-#         if prev_state == state:
-#             if ratio >= exit_ratio:
-#                 return state
-#         else:
-#             if ratio >= enter_ratio:
-#                 return state
-#     return 0.00
+def adc_to_grams(adc: float, cfg: SensorConfig) -> float:
+    if adc <= 0:
+        return 0.0
+    return (adc / cfg.a_const) ** (1.0 / cfg.b_const)
 
+# ──────────────────────────────────────────────────────────────────────────────
+# Per-sensor fault tracker
+# ──────────────────────────────────────────────────────────────────────────────
 
-# ------- MAIN -------
-def main():
-    print("Process A started")
+class SensorFaultTracker:
+    """
+    Counts consecutive read errors per sensor.
+    Once `threshold` is reached, the sensor is marked faulted and
+    logged at ERROR level (not every single cycle).
+    """
 
-    sensors = ["Z1_A0", "Z1_A1", "Z1_A2"]
+    def __init__(self, sensor_id: str, threshold: int = CONFIG.fault_threshold):
+        self.sensor_id        = sensor_id
+        self.threshold        = threshold
+        self._consecutive     = 0
+        self._is_faulted      = False
 
-    filters = {s: MovingAverage(WINDOW_SIZE) for s in sensors}
-    compensators = {s: DriftCompensator() for s in sensors}
-    # states = {s: 0.0 for s in sensors}
+    def record_success(self) -> None:
+        if self._is_faulted:
+            log.info("Sensor %s recovered after fault.", self.sensor_id)
+            self._is_faulted = False
+        self._consecutive = 0
 
-    active_mode = True   # wake/sleep flag
+    def record_failure(self, exc: Exception) -> None:
+        self._consecutive += 1
+        if self._consecutive >= self.threshold and not self._is_faulted:
+            log.error(
+                "Sensor %s faulted after %d consecutive errors. "
+                "Last error: %s",
+                self.sensor_id, self._consecutive, exc,
+            )
+            self._is_faulted = True
+        elif not self._is_faulted:
+            log.warning("Sensor %s read error (%d/%d): %s",
+                        self.sensor_id, self._consecutive,
+                        self.threshold, exc)
 
+    @property
+    def is_faulted(self) -> bool:
+        return self._is_faulted
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Main loop
+# ──────────────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    log.info("=" * 60)
+    log.info("PROCESS A STARTING  |  SHELF: %s", CONFIG.shelf_id)
+    log.info("Sensor sequence (scale_index order): %s", SENSOR_SEQUENCE)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    # ── Initialise per-sensor objects ─────────────────────────────────────────
+    filters:      Dict[str, MovingAverage]          = {}
+    compensators: Dict[str, PersistentDriftCompensator] = {}
+    fault_trackers: Dict[str, SensorFaultTracker]   = {}
+    channels:     Dict[str, Optional[AnalogIn]]     = {}
+
+    for s_id, cfg in SENSOR_MAP.items():
+        filters[s_id]       = MovingAverage(CONFIG.window_size)
+        compensators[s_id]  = PersistentDriftCompensator(s_id)
+        fault_trackers[s_id] = SensorFaultTracker(s_id)
+        # Channel init: failure here only faults this ADC, not the process
+        channels[s_id] = HardwareManager.get_adc_channel(
+            cfg.adc_address, cfg.adc_channel
+        )
+        status = "OK" if channels[s_id] is not None else "FAULTED (ADC init failed)"
+        log.info("Channel %s at 0x%02X ch%d → %s",
+                 s_id, cfg.adc_address, cfg.adc_channel, status)
+
+    log.info("Initialisation complete. Entering read loop.")
+
+    # ── Read loop ─────────────────────────────────────────────────────────────
     while True:
-        try:
-            for i, sensor in enumerate(sensors):
-                raw = read_adc1(sensor)
+        timestamp          = datetime.now(timezone.utc).isoformat()
+        any_weight_detected = False
 
-                # Deadzone: clamp noise floor to 0
-                clean = 0 if raw < DEADZONE_ADC else raw
+        # enumerate(SENSOR_SEQUENCE) is the ONLY place scale_index is assigned.
+        for scale_index, s_id in enumerate(SENSOR_SEQUENCE):
+            cfg     = SENSOR_MAP[s_id]
+            channel = channels[s_id]
 
-                # Moving average: smooth crosstalk jitter
-                smoothed = filters[sensor].add(clean)
-
-                # Drift compensation: neutralise creep
-                corrected = compensators[sensor].correct(sensor, smoothed)
-
-                # Calibrate
-                est_grams = adc_to_grams(corrected)
-
-                # Ratio + hysteretic state mapping
-                full_ref  = FULL_WEIGHT_G.get(sensor, 1000.0)
-                ratio     = est_grams / full_ref if full_ref > 0 else 0.0
-                # new_state = determine_state(ratio, states[sensor])
-                # states[sensor] = new_state
-
-                # UDP payload
+            # ── ADC-level fault: entire chip is down ──────────────────────────
+            if channel is None or HardwareManager.is_address_faulted(cfg.adc_address):
                 payload = {
-                    "shelf_id":   SHELF_ID,
-                    "scale_index": i, # to keep track of what scale/item
-                    "est_grams":  round(est_grams, 2),
-                    # "state":      new_state,
-                    "sampled_at": datetime.now(timezone.utc).isoformat(), # should Process A handle this or Process B? 
+                    "est_grams":   None,
+                    "shelf_id":    CONFIG.shelf_id,
+                    "sampled_at":  timestamp,
+                    "scale_index": scale_index,
+                    "adc_fault":   True,
+                    "sensor_id":   s_id,
                 }
+                sock.sendto(
+                    json.dumps(payload).encode(),
+                    (CONFIG.udp_ip, CONFIG.udp_port),
+                )
+                log.debug("[%s] scale_index=%d  ADC FAULTED – null payload sent.",
+                          s_id, scale_index)
+                continue
 
-                sock.sendto(json.dumps(payload).encode(), (UDP_IP, UDP_PORT))
-                print(f"[Process A] {payload}")
+            # ── Normal read path ──────────────────────────────────────────────
+            try:
+                raw_val   = channel.value
+                clean     = 0 if raw_val < CONFIG.deadzone_adc else raw_val
+                smoothed  = filters[s_id].add(float(clean))
+                corrected = compensators[s_id].correct(smoothed)
+                grams     = adc_to_grams(corrected, cfg)
 
-            interval = SAMPLE_INTERVAL_ACTIVE if active_mode else SAMPLE_INTERVAL_IDLE
-            time.sleep(interval)
+                fault_trackers[s_id].record_success()
 
-        except KeyboardInterrupt:
-            print("\nProcess A: shutting down.")
-            break
+                if grams > 10.0:
+                    any_weight_detected = True
+
+                # Terminal diagnostic line
+                zone = "Z1" if cfg.adc_address == 0x48 else "Z2"
+                print(
+                    f"[{s_id}({zone}|idx={scale_index})] "
+                    f"ADC:{raw_val:5}  Corr:{corrected:7.1f}  g:{grams:7.2f}"
+                )
+
+                payload = {
+                    "est_grams":   round(grams, 2),
+                    "shelf_id":    CONFIG.shelf_id,
+                    "sampled_at":  timestamp,
+                    "scale_index": scale_index,
+                    "adc_fault":   False,
+                }
+                sock.sendto(
+                    json.dumps(payload).encode(),
+                    (CONFIG.udp_ip, CONFIG.udp_port),
+                )
+
+            except Exception as exc:
+                fault_trackers[s_id].record_failure(exc)
+                # Send a fault payload so Process B doesn't stall waiting
+                # for a reading that will never arrive this cycle
+                payload = {
+                    "est_grams":   None,
+                    "shelf_id":    CONFIG.shelf_id,
+                    "sampled_at":  timestamp,
+                    "scale_index": scale_index,
+                    "adc_fault":   True,
+                    "sensor_id":   s_id,
+                }
+                sock.sendto(
+                    json.dumps(payload).encode(),
+                    (CONFIG.udp_ip, CONFIG.udp_port),
+                )
+
+        time.sleep(
+            CONFIG.interval_active if any_weight_detected else CONFIG.interval_idle
+        )
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        log.info("Process A stopped by keyboard interrupt.")
+    except Exception as exc:
+        log.critical("Process A crashed: %s", exc, exc_info=True)
+        raise

--- a/process-b/deploy/README.md
+++ b/process-b/deploy/README.md
@@ -7,6 +7,14 @@ This directory contains the deployment artifacts for running Process B as a mana
 | `process-b.service`         | systemd unit definition.                                  |
 | `process-b.env.example`     | Template for the environment file (`PI_API_KEY`, etc.).   |
 
+> **Which deploy path should I use?**
+>
+> - **Production / shipping the Pi** → use the **root-level orchestrator** (`/deploy/install.sh` + `shelfaware-orchestrator.service`). The orchestrator handles AP-mode provisioning, ping-based mode switching, and starts Process A / B / C as child processes. Process B does **not** run as its own systemd service in this path — the orchestrator is its parent.
+> - **Running Process B alone** (no orchestrator, no Process A on the same Pi, e.g. for isolated dev/test or a non-Pi Linux box) → use the artifacts in *this* directory. They install Process B as a standalone systemd service.
+> - **Foreground / interactive run during development** → see [Quick start](#quick-start-foreground--interactive-run) below. No systemd at all.
+>
+> The two systemd paths are mutually exclusive — don't enable both at once or you'll have two processes fighting for the same UDP port and SQLite file.
+
 The runbook below assumes the Pi is reached over SSH via [Tailscale](https://tailscale.com). If you're on the same LAN as the Pi, replace `<pi-tailnet-name>` with the Pi's hostname or IP everywhere — every step after SSH is identical.
 
 ---

--- a/process-b/process_b/backend_client.py
+++ b/process-b/process_b/backend_client.py
@@ -101,6 +101,28 @@ class CommandsResponse(BaseModel):
     commands: list[Command] = Field(default_factory=list)
 
 
+class ShelfRegistrationRequest(BaseModel):
+    """Request body for ``POST /shelves`` (provisioning callback)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    shelf_id: str
+    user_id: str
+
+
+class ShelfRegistrationResponse(BaseModel):
+    """Parsed body from ``POST /shelves``.
+
+    The backend's exact response shape is still being designed (see
+    :meth:`BackendClient.register_shelf`); we accept any extra fields and
+    only require the ``shelf_id`` echo so we can confirm the round-trip.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    shelf_id: str
+
+
 _DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0)
 
 
@@ -186,6 +208,34 @@ class BackendClient:
         response = await self._request("GET", "/commands", shelf_id=shelf_id)
         parsed = _parse(response, CommandsResponse)
         return parsed.commands
+
+    async def register_shelf(
+        self, *, shelf_id: str, user_id: str
+    ) -> ShelfRegistrationResponse:
+        """POST a (shelf_id, user_id) pair so the backend creates / confirms
+        the shelves row.
+
+        Idempotency is the backend's responsibility (key on ``shelf_id``):
+        Process B calls this on every startup so a shelf row dropped from
+        the database is self-healing.
+
+        Raises
+        ------
+        TransientBackendError
+            5xx, network error, or timeout. Caller should retry.
+        PermanentBackendError
+            4xx or malformed-but-200. Caller should log loudly but keep
+            running — the daemon's other duties (telemetry, polling) are
+            still useful even if registration is wedged.
+        """
+        body = ShelfRegistrationRequest(
+            shelf_id=shelf_id, user_id=user_id
+        ).model_dump(mode="json")
+
+        response = await self._request(
+            "POST", "/shelves", shelf_id=shelf_id, json=body
+        )
+        return _parse(response, ShelfRegistrationResponse)
 
     async def _request(
         self,

--- a/process-b/process_b/config.py
+++ b/process-b/process_b/config.py
@@ -15,6 +15,9 @@ import os
 from dataclasses import dataclass
 from typing import Mapping
 
+from process_b import device_state
+from process_b.device_state import DeviceStateError
+
 
 class ConfigError(ValueError):
     """Raised when one or more required env vars are missing or malformed.
@@ -32,7 +35,15 @@ class Config:
     backend_url: str
     db_path: str
 
+    # If device.json was present at startup, ``shelf_ids`` is a single-element
+    # tuple containing its shelf_id and ``user_id`` is the bound user.
+    # If device.json was absent (legacy / dev), ``shelf_ids`` comes from the
+    # SHELF_IDS env var and ``user_id`` is ``None`` (no shelf-registration
+    # call will be made by main.py).
     shelf_ids: tuple[str, ...]
+    user_id: str | None
+
+    device_file_path: str
 
     udp_listen_host: str
     udp_listen_port: int
@@ -98,13 +109,37 @@ class Config:
         backend_url = require("BACKEND_URL").rstrip("/")
         db_path = require("DB_PATH")
 
-        shelf_ids_raw = require("SHELF_IDS")
+        device_file_path = optional("DEVICE_FILE_PATH", "/etc/shelfaware/device.json")
+
+        # Resolve shelf identity. Precedence:
+        #   1. device.json (Process C wrote it at provisioning time)
+        #   2. SHELF_IDS env var (legacy / dev / pre-provisioning)
+        # If both are present, device.json wins; the env var is ignored. If
+        # device.json exists but is malformed, fail loud — silently falling
+        # back to env would mask real corruption.
         shelf_ids: tuple[str, ...] = ()
-        if shelf_ids_raw:
-            parts = tuple(s.strip() for s in shelf_ids_raw.split(",") if s.strip())
-            if not parts:
-                errors.append("SHELF_IDS must contain at least one shelf UUID")
-            shelf_ids = parts
+        user_id: str | None = None
+        try:
+            persisted = device_state.read(device_file_path)
+        except DeviceStateError as exc:
+            errors.append(f"DEVICE_FILE_PATH ({device_file_path}) is unreadable: {exc}")
+            persisted = None
+
+        if persisted is not None:
+            shelf_ids = (persisted.shelf_id,)
+            user_id = persisted.user_id
+        else:
+            shelf_ids_raw = source.get("SHELF_IDS", "").strip()
+            if not shelf_ids_raw:
+                errors.append(
+                    "SHELF_IDS is required when no device.json is present at "
+                    f"{device_file_path} (Process C writes the file at provisioning time)"
+                )
+            else:
+                parts = tuple(s.strip() for s in shelf_ids_raw.split(",") if s.strip())
+                if not parts:
+                    errors.append("SHELF_IDS must contain at least one shelf UUID")
+                shelf_ids = parts
 
         udp_listen_host = optional("UDP_LISTEN_HOST", "0.0.0.0")
         udp_listen_port_raw = require("UDP_LISTEN_PORT")
@@ -138,6 +173,8 @@ class Config:
             backend_url=backend_url,
             db_path=db_path,
             shelf_ids=shelf_ids,
+            user_id=user_id,
+            device_file_path=device_file_path,
             udp_listen_host=udp_listen_host,
             udp_listen_port=udp_listen_port,
             proc_a_control_host=proc_a_control_host,

--- a/process-b/process_b/device_state.py
+++ b/process-b/process_b/device_state.py
@@ -1,0 +1,80 @@
+"""Read-only access to ``device.json`` from Process C.
+
+Process C owns writes to this file at provisioning time. Process B only
+ever reads it — once at startup, to learn its ``shelf_id`` and the
+``user_id`` it should register with the backend.
+
+The file lives at ``DEVICE_FILE_PATH`` (default
+``/etc/shelfaware/device.json``). Format is documented in
+:mod:`process_c.device_state`; we only depend on a stable read shape so
+the two packages don't need a shared library.
+
+Why a separate module from process_c.device_state
+-------------------------------------------------
+Process B and Process C are independent installables that may run on
+different deploy paths and at different versions. Coupling them via a
+shared package would mean either splitting out a third package
+(``process-shared``) or making B import C, which inverts the lifecycle
+direction (C is the writer, B is the reader; readers shouldn't import
+writers). A 30-line copy is the right amount of duplication.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class DeviceStateError(Exception):
+    """Raised when device.json exists but is malformed."""
+
+
+@dataclass(frozen=True)
+class DeviceState:
+    user_id: str
+    shelf_id: str
+    provisioned_at: str
+    schema_version: int = 1
+
+
+def read(path: str | os.PathLike[str]) -> DeviceState | None:
+    """Return the persisted :class:`DeviceState`, or ``None`` if absent.
+
+    Raises :class:`DeviceStateError` if the file exists but is malformed
+    — callers should treat that as a hard failure rather than silently
+    fall back to env-var config (corrupted state should be operator-fixed,
+    not papered over).
+    """
+    p = Path(path)
+    if not p.exists():
+        return None
+
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise DeviceStateError(f"could not read {p}: {exc}") from exc
+
+    try:
+        data: Any = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise DeviceStateError(f"{p} is not valid JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise DeviceStateError(f"{p} root must be a JSON object")
+
+    missing = [k for k in ("user_id", "shelf_id", "provisioned_at") if k not in data]
+    if missing:
+        raise DeviceStateError(f"{p} missing required fields: {missing}")
+
+    return DeviceState(
+        user_id=str(data["user_id"]),
+        shelf_id=str(data["shelf_id"]),
+        provisioned_at=str(data["provisioned_at"]),
+        schema_version=int(data.get("schema_version", 1)),
+    )

--- a/process-b/process_b/main.py
+++ b/process-b/process_b/main.py
@@ -32,7 +32,7 @@ from typing import NoReturn
 
 import aiosqlite
 
-from process_b import db, drainer, logging_setup, poller, udp_listener
+from process_b import db, drainer, logging_setup, poller, registrar, udp_listener
 from process_b.backend_client import BackendClient
 from process_b.config import Config, ConfigError
 
@@ -136,6 +136,20 @@ async def _run_workers(
             ),
             name="poller",
         )
+        # Best-effort shelf registration. Only runs when device.json was
+        # present (i.e. Process C provisioned this Pi); pre-provisioning
+        # / dev runs use SHELF_IDS env var with no user_id and skip this.
+        if config.user_id is not None:
+            for shelf_id in config.shelf_ids:
+                tg.create_task(
+                    registrar.register_with_backoff(
+                        client=client,
+                        shelf_id=shelf_id,
+                        user_id=config.user_id,
+                        stop_event=stop_event,
+                    ),
+                    name=f"registrar:{shelf_id[:8]}",
+                )
 
 
 def _install_signal_handlers(stop_event: asyncio.Event) -> None:

--- a/process-b/process_b/main.py
+++ b/process-b/process_b/main.py
@@ -63,6 +63,13 @@ def run() -> NoReturn:
     sys.exit(0)
 
 
+if __name__ == "__main__":
+    # Allows `python3 main.py` as well as the `process-b` console script.
+    # The orchestrator (orchestration/orchestrator.py) launches Process B
+    # by direct file path, so this block is required for that path.
+    run()
+
+
 async def main(config: Config) -> None:
     """Open resources, run the three worker tasks, clean up on exit."""
     stop_event = asyncio.Event()

--- a/process-b/process_b/registrar.py
+++ b/process-b/process_b/registrar.py
@@ -1,0 +1,127 @@
+"""Best-effort shelf registration with the backend.
+
+When ``device.json`` is present (i.e. Process C provisioned this Pi),
+Process B should tell the backend "hey, this shelf_id is bound to this
+user_id." We do this on **every startup** because the call is idempotent
+on the backend side, which makes the system self-healing if a shelves
+row is ever lost.
+
+Design
+------
+- Runs as a background asyncio task spawned by :mod:`process_b.main`.
+- Never blocks the rest of the daemon: UDP listener, drainer, and poller
+  all start normally regardless of registration outcome.
+- Retries transient failures with bounded exponential backoff.
+- On 4xx (permanent failure): logs ERROR loudly but exits the loop. Most
+  likely cause is a backend schema mismatch or a stale token; either way
+  no amount of retry will fix it.
+- On success: logs INFO and exits the loop.
+
+This intentionally does not persist a "registered with backend" marker
+to device.json. The backend is the source of truth for which shelves it
+knows about; if registration succeeded once but the shelves row was
+later dropped, we want the next restart to re-register.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from process_b.backend_client import (
+    BackendClient,
+    PermanentBackendError,
+    TransientBackendError,
+)
+
+logger = logging.getLogger(__name__)
+
+_BACKOFF_INITIAL_SEC = 5.0
+_BACKOFF_CAP_SEC = 120.0
+_BACKOFF_FACTOR = 2.0
+
+
+async def register_with_backoff(
+    *,
+    client: BackendClient,
+    shelf_id: str,
+    user_id: str,
+    stop_event: asyncio.Event,
+) -> None:
+    """Loop until registration succeeds, fails permanently, or shutdown.
+
+    Returns when one of:
+    - Backend returns 2xx (success).
+    - Backend returns 4xx (permanent — see module docstring).
+    - ``stop_event`` is set.
+
+    Never raises; all errors are logged.
+    """
+    delay = _BACKOFF_INITIAL_SEC
+    attempt = 0
+
+    while not stop_event.is_set():
+        attempt += 1
+        try:
+            response = await client.register_shelf(
+                shelf_id=shelf_id, user_id=user_id
+            )
+        except TransientBackendError as exc:
+            logger.warning(
+                "shelf registration transient failure; will retry",
+                extra={
+                    "shelf_id": shelf_id,
+                    "attempt": attempt,
+                    "delay_sec": delay,
+                    "status": exc.status,
+                },
+            )
+            if await _sleep_or_stop(delay, stop_event):
+                return
+            delay = min(delay * _BACKOFF_FACTOR, _BACKOFF_CAP_SEC)
+            continue
+        except PermanentBackendError as exc:
+            logger.error(
+                "shelf registration permanently rejected; giving up",
+                extra={
+                    "shelf_id": shelf_id,
+                    "user_id": user_id,
+                    "attempt": attempt,
+                    "status": exc.status,
+                    "body": exc.body,
+                },
+            )
+            return
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                "shelf registration raised unexpectedly; will retry",
+                extra={"shelf_id": shelf_id, "attempt": attempt, "delay_sec": delay},
+            )
+            if await _sleep_or_stop(delay, stop_event):
+                return
+            delay = min(delay * _BACKOFF_FACTOR, _BACKOFF_CAP_SEC)
+            continue
+
+        logger.info(
+            "shelf registered with backend",
+            extra={
+                "shelf_id": shelf_id,
+                "user_id": user_id,
+                "attempt": attempt,
+                "echoed_shelf_id": response.shelf_id,
+            },
+        )
+        return
+
+
+async def _sleep_or_stop(delay: float, stop_event: asyncio.Event) -> bool:
+    """Sleep ``delay`` seconds, but wake early if ``stop_event`` is set.
+
+    Returns ``True`` if shutdown was signalled (caller should bail out),
+    ``False`` if the delay elapsed normally.
+    """
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=delay)
+    except asyncio.TimeoutError:
+        return False
+    return True

--- a/process-b/process_b/udp_listener.py
+++ b/process-b/process_b/udp_listener.py
@@ -51,26 +51,40 @@ class IncomingReading(BaseModel):
         {
           "shelf_id": "<UUIDv4>",
           "scale_index": <int >= 0>,
-          "est_grams": <finite float>,
-          "sampled_at": "<ISO 8601 UTC string>"
+          "est_grams": <finite float | null>,
+          "sampled_at": "<ISO 8601 UTC string>",
+          "adc_fault": <bool, optional>      // true => sensor unavailable
         }
 
     ``sampled_at`` is kept as a string — the contract specifies ISO 8601
     UTC, and Process B forwards it verbatim to the backend. Round-tripping
     through a ``datetime`` would risk timezone-stripping bugs.
+
+    Fault handling: when ``adc_fault`` is true (or ``est_grams`` is null),
+    Process A is signalling that this sensor was unreadable this cycle.
+    The backend's telemetry schema requires a numeric ``est_grams`` so we
+    cannot forward null readings — they are dropped at the listener with
+    an INFO log. If we later want fault visibility on the frontend, the
+    right place to add it is a separate backend endpoint, not the
+    telemetry stream.
+
+    ``extra="ignore"`` keeps Process B forward-compatible with new
+    diagnostic fields Process A may add (battery, sensor_id, etc.) without
+    requiring a coordinated schema bump on every change.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     shelf_id: str = Field(min_length=1)
     scale_index: int = Field(ge=0)
-    est_grams: float
+    est_grams: float | None = None
     sampled_at: str = Field(min_length=1)
+    adc_fault: bool = False
 
     @field_validator("est_grams")
     @classmethod
-    def _est_grams_must_be_finite(cls, v: float) -> float:
-        if not math.isfinite(v):
+    def _est_grams_must_be_finite(cls, v: float | None) -> float | None:
+        if v is not None and not math.isfinite(v):
             raise ValueError("est_grams must be finite (no NaN, no infinity)")
         return v
 
@@ -102,6 +116,20 @@ class TelemetryProtocol(asyncio.DatagramProtocol):
                     "addr": addr,
                     "reason": exc.reason,
                     "size": len(data),
+                },
+            )
+            return
+
+        # Sensor-fault rows can't be forwarded — backend requires numeric grams.
+        # Log + drop here rather than persist a row that would never drain.
+        if reading.adc_fault or reading.est_grams is None:
+            logger.info(
+                "udp datagram skipped (sensor fault)",
+                extra={
+                    "addr": addr,
+                    "shelf_id": reading.shelf_id,
+                    "scale_index": reading.scale_index,
+                    "adc_fault": reading.adc_fault,
                 },
             )
             return

--- a/process-b/tests/test_backend_client.py
+++ b/process-b/tests/test_backend_client.py
@@ -279,6 +279,68 @@ class TestGetCommands:
         assert exc.value.status == 401
 
 
+class TestRegisterShelf:
+    @respx.mock
+    async def test_2xx_returns_parsed_response(self) -> None:
+        route = respx.post(f"{BASE_URL}/shelves").mock(
+            return_value=httpx.Response(
+                200, json={"shelf_id": SHELF_A, "user_id": "u1"}
+            )
+        )
+
+        async with _client() as client:
+            result = await client.register_shelf(shelf_id=SHELF_A, user_id="u1")
+
+        assert result.shelf_id == SHELF_A
+        assert route.called
+
+    @respx.mock
+    async def test_sends_required_headers_and_body(self) -> None:
+        captured: dict[str, object] = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = request.content
+            captured["auth"] = request.headers.get("Authorization")
+            captured["shelf_header"] = request.headers.get("X-Shelf-Id")
+            return httpx.Response(201, json={"shelf_id": SHELF_A})
+
+        respx.post(f"{BASE_URL}/shelves").mock(side_effect=capture)
+
+        async with _client() as client:
+            await client.register_shelf(shelf_id=SHELF_A, user_id="u1")
+
+        import json as _json
+
+        body = _json.loads(captured["body"])  # type: ignore[arg-type]
+        assert body == {"shelf_id": SHELF_A, "user_id": "u1"}
+        assert captured["auth"] == f"Bearer {API_KEY}"
+        assert captured["shelf_header"] == SHELF_A
+
+    @respx.mock
+    async def test_5xx_raises_transient_error(self) -> None:
+        respx.post(f"{BASE_URL}/shelves").mock(
+            return_value=httpx.Response(503, text="upstream down")
+        )
+
+        async with _client() as client:
+            with pytest.raises(TransientBackendError) as exc:
+                await client.register_shelf(shelf_id=SHELF_A, user_id="u1")
+
+        assert exc.value.status == 503
+
+    @respx.mock
+    async def test_4xx_raises_permanent_error(self) -> None:
+        respx.post(f"{BASE_URL}/shelves").mock(
+            return_value=httpx.Response(400, text="invalid user_id")
+        )
+
+        async with _client() as client:
+            with pytest.raises(PermanentBackendError) as exc:
+                await client.register_shelf(shelf_id=SHELF_A, user_id="u1")
+
+        assert exc.value.status == 400
+
+
 class TestLifecycle:
     async def test_aclose_closes_underlying_client(self) -> None:
         client = _client()

--- a/process-b/tests/test_config.py
+++ b/process-b/tests/test_config.py
@@ -6,6 +6,9 @@ These are pure-function tests over a synthetic env mapping. We never touch
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from process_b.config import Config, ConfigError
@@ -15,8 +18,19 @@ SHELF_A = "550e8400-e29b-41d4-a716-446655440000"
 SHELF_B = "660e8400-e29b-41d4-a716-446655440001"
 
 
-def _minimal_env(**overrides: str) -> dict[str, str]:
-    """Return a valid env mapping; tests override individual keys."""
+def _minimal_env(*, tmp_path: Path | None = None, **overrides: str) -> dict[str, str]:
+    """Return a valid env mapping; tests override individual keys.
+
+    ``DEVICE_FILE_PATH`` is pointed at a guaranteed-nonexistent path inside
+    ``tmp_path`` (or a fixed garbage path) so happy-path tests exercise the
+    env-fallback branch deterministically. Tests that want to drive the
+    device.json branch must override ``DEVICE_FILE_PATH`` themselves.
+    """
+    if tmp_path is not None:
+        device_file = str(tmp_path / "absent-device.json")
+    else:
+        device_file = "/nonexistent/device.json"
+
     env = {
         "PI_API_KEY": "secret",
         "BACKEND_URL": "https://api.example.com/",
@@ -24,6 +38,7 @@ def _minimal_env(**overrides: str) -> dict[str, str]:
         "SHELF_IDS": SHELF_A,
         "UDP_LISTEN_PORT": "5005",
         "PROC_A_CONTROL_PORT": "5006",
+        "DEVICE_FILE_PATH": device_file,
     }
     env.update(overrides)
     return env
@@ -48,6 +63,9 @@ class TestHappyPath:
         assert cfg.poll_interval_sec == pytest.approx(3.0)
 
         assert cfg.log_level == "INFO"
+        # No device.json present → user_id stays None and shelf_ids comes
+        # from the env var (legacy / pre-provisioning path).
+        assert cfg.user_id is None
 
     def test_optionals_when_provided_override_defaults(self) -> None:
         cfg = Config.from_env(
@@ -118,3 +136,74 @@ class TestErrors:
         with pytest.raises(ConfigError) as exc:
             Config.from_env(_minimal_env(SHELF_IDS=" , , "))
         assert "SHELF_IDS" in str(exc.value)
+
+
+class TestDeviceFile:
+    """Behaviour around DEVICE_FILE_PATH and the shelf_id precedence rule."""
+
+    def _write_device_json(
+        self, path: Path, *, user_id: str = "user-uuid-1", shelf_id: str = SHELF_B
+    ) -> None:
+        path.write_text(
+            json.dumps(
+                {
+                    "user_id": user_id,
+                    "shelf_id": shelf_id,
+                    "provisioned_at": "2026-05-04T07:00:00Z",
+                    "schema_version": 1,
+                }
+            )
+        )
+
+    def test_device_json_wins_over_env_shelf_ids(self, tmp_path: Path) -> None:
+        device_path = tmp_path / "device.json"
+        self._write_device_json(device_path, user_id="u-from-file", shelf_id=SHELF_B)
+
+        cfg = Config.from_env(
+            _minimal_env(
+                tmp_path=tmp_path,
+                DEVICE_FILE_PATH=str(device_path),
+                SHELF_IDS=SHELF_A,  # should be ignored
+            )
+        )
+
+        assert cfg.shelf_ids == (SHELF_B,)
+        assert cfg.user_id == "u-from-file"
+        assert cfg.device_file_path == str(device_path)
+
+    def test_no_device_json_falls_back_to_env(self, tmp_path: Path) -> None:
+        # _minimal_env points DEVICE_FILE_PATH at an absent file under tmp_path.
+        cfg = Config.from_env(_minimal_env(tmp_path=tmp_path))
+        assert cfg.shelf_ids == (SHELF_A,)
+        assert cfg.user_id is None
+
+    def test_no_device_json_and_no_env_shelf_ids_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        env = _minimal_env(tmp_path=tmp_path)
+        del env["SHELF_IDS"]
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(env)
+        # Error message should be helpful — mention both alternatives.
+        assert "SHELF_IDS" in str(exc.value)
+        assert "device.json" in str(exc.value)
+
+    def test_malformed_device_json_is_rejected_loudly(self, tmp_path: Path) -> None:
+        device_path = tmp_path / "device.json"
+        device_path.write_text("not valid json")
+
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(
+                _minimal_env(tmp_path=tmp_path, DEVICE_FILE_PATH=str(device_path))
+            )
+        # Don't silently fall back to env when device.json is corrupt —
+        # operator must look.
+        assert "DEVICE_FILE_PATH" in str(exc.value)
+
+    def test_device_file_path_default(self, tmp_path: Path) -> None:
+        # When DEVICE_FILE_PATH is unset, default is /etc/shelfaware/device.json.
+        # (Almost certainly absent on the test box; use the env-fallback path.)
+        env = _minimal_env(tmp_path=tmp_path)
+        del env["DEVICE_FILE_PATH"]
+        cfg = Config.from_env(env)
+        assert cfg.device_file_path == "/etc/shelfaware/device.json"

--- a/process-b/tests/test_device_state.py
+++ b/process-b/tests/test_device_state.py
@@ -1,0 +1,67 @@
+"""Tests for :mod:`process_b.device_state` (Process B's read-only view of device.json)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from process_b import device_state
+from process_b.device_state import DeviceState, DeviceStateError
+
+
+@pytest.fixture
+def device_path(tmp_path: Path) -> Path:
+    return tmp_path / "device.json"
+
+
+class TestRead:
+    def test_returns_none_when_file_missing(self, device_path: Path) -> None:
+        assert device_state.read(device_path) is None
+
+    def test_returns_state_for_well_formed_file(self, device_path: Path) -> None:
+        device_path.write_text(
+            json.dumps(
+                {
+                    "user_id": "u1",
+                    "shelf_id": "s1",
+                    "provisioned_at": "2026-05-04T07:00:00Z",
+                    "schema_version": 1,
+                }
+            )
+        )
+        result = device_state.read(device_path)
+        assert result == DeviceState(
+            user_id="u1",
+            shelf_id="s1",
+            provisioned_at="2026-05-04T07:00:00Z",
+            schema_version=1,
+        )
+
+    def test_default_schema_version_when_missing(self, device_path: Path) -> None:
+        device_path.write_text(
+            json.dumps(
+                {"user_id": "u", "shelf_id": "s", "provisioned_at": "2026-01-01T00:00:00Z"}
+            )
+        )
+        state = device_state.read(device_path)
+        assert state is not None
+        assert state.schema_version == 1
+
+    def test_raises_when_not_json(self, device_path: Path) -> None:
+        device_path.write_text("not json")
+        with pytest.raises(DeviceStateError) as exc:
+            device_state.read(device_path)
+        assert "JSON" in str(exc.value)
+
+    def test_raises_when_root_is_not_object(self, device_path: Path) -> None:
+        device_path.write_text("[1, 2, 3]")
+        with pytest.raises(DeviceStateError):
+            device_state.read(device_path)
+
+    def test_raises_when_required_field_missing(self, device_path: Path) -> None:
+        device_path.write_text(json.dumps({"user_id": "u", "shelf_id": "s"}))
+        with pytest.raises(DeviceStateError) as exc:
+            device_state.read(device_path)
+        assert "provisioned_at" in str(exc.value)

--- a/process-b/tests/test_main.py
+++ b/process-b/tests/test_main.py
@@ -48,6 +48,8 @@ def _make_config(tmp_path: Path, *, udp_port: int) -> Config:
         backend_url=BASE_URL,
         db_path=str(tmp_path / "outbox.db"),
         shelf_ids=(SHELF_A,),
+        user_id=None,  # legacy / dev path: no device.json, skip registration
+        device_file_path=str(tmp_path / "device.json"),
         udp_listen_host="127.0.0.1",
         udp_listen_port=udp_port,
         proc_a_control_host="127.0.0.1",

--- a/process-b/tests/test_registrar.py
+++ b/process-b/tests/test_registrar.py
@@ -1,0 +1,136 @@
+"""Tests for :mod:`process_b.registrar`."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from process_b.backend_client import (
+    PermanentBackendError,
+    ShelfRegistrationResponse,
+    TransientBackendError,
+)
+from process_b.registrar import register_with_backoff
+
+
+SHELF = "shelf-uuid-1"
+USER = "user-uuid-1"
+
+
+class _FakeClient:
+    """Minimal stand-in for BackendClient.register_shelf().
+
+    Each call pops the next response from ``responses`` and either returns
+    it or raises it. Callers track ``calls`` to assert behaviour.
+    """
+
+    def __init__(self, responses: list) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[str, str]] = []
+
+    async def register_shelf(
+        self, *, shelf_id: str, user_id: str
+    ) -> ShelfRegistrationResponse:
+        self.calls.append((shelf_id, user_id))
+        if not self.responses:
+            raise AssertionError("ran out of canned responses")
+        nxt = self.responses.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+
+# Patch _BACKOFF_INITIAL_SEC to something tiny so tests run fast.
+@pytest.fixture(autouse=True)
+def _fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    from process_b import registrar as _r
+
+    monkeypatch.setattr(_r, "_BACKOFF_INITIAL_SEC", 0.001)
+    monkeypatch.setattr(_r, "_BACKOFF_CAP_SEC", 0.01)
+
+
+class TestRegisterWithBackoff:
+    async def test_success_first_try(self) -> None:
+        client = _FakeClient([ShelfRegistrationResponse(shelf_id=SHELF)])
+        stop = asyncio.Event()
+
+        await register_with_backoff(
+            client=client, shelf_id=SHELF, user_id=USER, stop_event=stop
+        )
+
+        assert client.calls == [(SHELF, USER)]
+
+    async def test_retries_on_transient_then_succeeds(self) -> None:
+        client = _FakeClient(
+            [
+                TransientBackendError("net dead", status=502),
+                TransientBackendError("net dead", status=503),
+                ShelfRegistrationResponse(shelf_id=SHELF),
+            ]
+        )
+        stop = asyncio.Event()
+
+        await register_with_backoff(
+            client=client, shelf_id=SHELF, user_id=USER, stop_event=stop
+        )
+
+        assert len(client.calls) == 3
+
+    async def test_permanent_failure_exits_immediately(self) -> None:
+        client = _FakeClient(
+            [
+                PermanentBackendError(
+                    "validation failed", status=400, body='{"error":"x"}'
+                )
+            ]
+        )
+        stop = asyncio.Event()
+
+        await register_with_backoff(
+            client=client, shelf_id=SHELF, user_id=USER, stop_event=stop
+        )
+
+        # Permanent → no retry.
+        assert len(client.calls) == 1
+
+    async def test_stop_event_breaks_retry_loop(self) -> None:
+        # Always-transient: would retry forever without stop_event.
+        client = _FakeClient(
+            [TransientBackendError("dead", status=503) for _ in range(100)]
+        )
+        stop = asyncio.Event()
+
+        async def trip_after_some_attempts() -> None:
+            # Wait until at least one retry has happened.
+            for _ in range(200):
+                if len(client.calls) >= 2:
+                    stop.set()
+                    return
+                await asyncio.sleep(0.001)
+            stop.set()  # safety
+
+        await asyncio.gather(
+            register_with_backoff(
+                client=client, shelf_id=SHELF, user_id=USER, stop_event=stop
+            ),
+            trip_after_some_attempts(),
+        )
+
+        # Should have stopped well before the 100 canned responses ran out.
+        assert len(client.calls) < 100
+
+    async def test_unexpected_exception_is_treated_as_transient(self) -> None:
+        client = _FakeClient(
+            [
+                RuntimeError("something wild"),
+                ShelfRegistrationResponse(shelf_id=SHELF),
+            ]
+        )
+        stop = asyncio.Event()
+
+        await register_with_backoff(
+            client=client, shelf_id=SHELF, user_id=USER, stop_event=stop
+        )
+
+        assert len(client.calls) == 2

--- a/process-b/tests/test_udp_listener.py
+++ b/process-b/tests/test_udp_listener.py
@@ -50,7 +50,7 @@ def _datagram(
     *,
     shelf_id: str = SHELF_A,
     scale_index: int = 0,
-    est_grams: float = 750.2,
+    est_grams: float | None = 750.2,
     sampled_at: str = "2026-04-21T08:30:00Z",
     extra: dict | None = None,
 ) -> bytes:
@@ -117,9 +117,33 @@ class TestParseDatagram:
         with pytest.raises(Exception):
             _parse_datagram(bad)
 
-    def test_unknown_field_is_rejected_due_to_extra_forbid(self) -> None:
-        with pytest.raises(Exception):
-            _parse_datagram(_datagram(extra={"surprise": "field"}))
+    def test_unknown_field_is_ignored(self) -> None:
+        # Schema is intentionally permissive (extra="ignore") so that new
+        # diagnostic fields from Process A (battery, sensor_id, ...) don't
+        # require a coordinated schema bump on every change.
+        result = _parse_datagram(_datagram(extra={"surprise": "field"}))
+        assert isinstance(result, IncomingReading)
+        assert result.shelf_id == SHELF_A
+
+    def test_adc_fault_field_is_parsed(self) -> None:
+        result = _parse_datagram(
+            _datagram(est_grams=None, extra={"adc_fault": True})  # type: ignore[arg-type]
+        )
+        assert result.adc_fault is True
+        assert result.est_grams is None
+
+    def test_adc_fault_defaults_false_when_omitted(self) -> None:
+        result = _parse_datagram(_datagram())
+        assert result.adc_fault is False
+
+    def test_null_est_grams_is_accepted_when_fault(self) -> None:
+        # est_grams: None is allowed at the parse layer; the persister is
+        # responsible for dropping fault rows. Keeping parse permissive lets
+        # us log/diagnose them rather than treating them as malformed.
+        result = _parse_datagram(
+            _datagram(est_grams=None, extra={"adc_fault": True})  # type: ignore[arg-type]
+        )
+        assert result.est_grams is None
 
     def test_negative_scale_index_is_rejected(self) -> None:
         with pytest.raises(Exception):
@@ -200,13 +224,38 @@ class TestProtocolPersistence:
         protocol.datagram_received(_datagram(scale_index=0), LOCAL_ADDR)
         protocol.datagram_received(b"garbage", LOCAL_ADDR)
         protocol.datagram_received(_datagram(scale_index=1, sampled_at="2026-04-21T08:30:01Z"), LOCAL_ADDR)
-        protocol.datagram_received(_datagram(extra={"unexpected": True}), LOCAL_ADDR)
+        protocol.datagram_received(b"\xff\xfe not utf-8", LOCAL_ADDR)
         protocol.datagram_received(_datagram(scale_index=2, sampled_at="2026-04-21T08:30:02Z"), LOCAL_ADDR)
 
         rows = await _wait_for_rows(db_conn, expected=3)
         await _drain_protocol_tasks(protocol)
         rows = await db.claim_batch(db_conn, batch_size=1000)
         assert {r.scale_index for r in rows} == {0, 1, 2}
+
+    async def test_adc_fault_datagram_is_skipped_not_persisted(
+        self, db_conn: aiosqlite.Connection
+    ) -> None:
+        # adc_fault=True means the sensor was unreadable this cycle. The
+        # backend's telemetry schema requires numeric est_grams so we can't
+        # forward it; drop at the listener instead of persisting an
+        # un-drainable row.
+        protocol = TelemetryProtocol(db_conn)
+
+        protocol.datagram_received(
+            _datagram(scale_index=0, est_grams=None, extra={"adc_fault": True}),  # type: ignore[arg-type]
+            LOCAL_ADDR,
+        )
+        protocol.datagram_received(_datagram(scale_index=1), LOCAL_ADDR)
+        protocol.datagram_received(
+            _datagram(scale_index=2, est_grams=None, extra={"adc_fault": True}),  # type: ignore[arg-type]
+            LOCAL_ADDR,
+        )
+
+        rows = await _wait_for_rows(db_conn, expected=1)
+        await _drain_protocol_tasks(protocol)
+        rows = await db.claim_batch(db_conn, batch_size=1000)
+        assert len(rows) == 1
+        assert rows[0].scale_index == 1
 
     async def test_aclose_drains_in_flight_tasks(
         self, db_conn: aiosqlite.Connection

--- a/process-c/README.md
+++ b/process-c/README.md
@@ -1,0 +1,67 @@
+# Process C — Setup Daemon
+
+Process C is the **first-time setup HTTP server** for the ShelfAware Pi.
+
+It runs **only when the Pi has no internet** (i.e. fresh out of the box, or
+after the user's WiFi credentials become invalid). The boot orchestrator
+(`/orchestration/orchestrator.py`) detects the offline state, switches the
+Pi into AP mode (broadcasting `ShelfAware_Setup`), and starts Process C +
+Process B together.
+
+The user joins the Pi's hotspot from their phone, opens the ShelfAware app,
+and submits their home WiFi credentials + their `user_id`. Process C:
+
+1. Validates the input.
+2. Generates a fresh `shelf_id` (UUIDv4) and persists `device.json` to
+   `/etc/shelfaware/device.json`.
+3. Returns `202 Accepted` to the app immediately.
+4. Hands the credentials to `wifi_connector.apply_wifi_credentials()` in a
+   background task. wifi_connector either successfully joins the home WiFi
+   (and the orchestrator restarts everything in online mode), or rolls
+   back to AP mode within ~60s so the user can retry.
+5. Process B reads the freshly-written `device.json` on its next start
+   and registers the shelf with the backend via `POST /shelves`.
+
+Process C dies once provisioning completes — the orchestrator kills it
+when it switches to online mode.
+
+## Endpoints
+
+| Method | Path        | Purpose                                    |
+| ------ | ----------- | ------------------------------------------ |
+| GET    | `/health`   | Frontend probe to detect "I'm on a Pi"     |
+| POST   | `/provision`| Submit WiFi creds + user_id                |
+| POST   | `/reset`    | (debug) wipe device.json — disabled by default |
+
+See `process_c/handlers.py` for full request/response schemas.
+
+## Running
+
+For local dev (no real WiFi switching):
+
+```bash
+cd process-c
+python -m venv .venv
+source .venv/bin/activate          # PowerShell: .venv\Scripts\Activate.ps1
+pip install -e ".[dev]"
+
+export SHELFAWARE_DEV=1            # mocks wifi_connector — safe over Tailscale
+export DEVICE_FILE_PATH=./device.json
+export BIND_HOST=127.0.0.1
+export BIND_PORT=8080
+
+process-c
+```
+
+Then in another terminal:
+
+```bash
+curl http://127.0.0.1:8080/health
+curl -X POST http://127.0.0.1:8080/provision \
+  -H "Content-Type: application/json" \
+  -d '{"ssid":"MyWifi","password":"hunter2","user_id":"550e8400-e29b-41d4-a716-446655440000"}'
+cat ./device.json
+```
+
+In production (on the Pi) the orchestrator launches Process C with
+`SHELFAWARE_DEV=0` and the default bind `0.0.0.0:80`.

--- a/process-c/deploy/README.md
+++ b/process-c/deploy/README.md
@@ -1,0 +1,174 @@
+# Process C deploy runbook
+
+Process C is the **first-time setup HTTP server**. It runs only when the
+Pi is in AP (hotspot) mode, accepts WiFi credentials + a `user_id` from
+the companion app, writes `device.json`, and hands off to
+`orchestration/wifi_connector.py` to switch to STA mode.
+
+> [!NOTE]
+> **Three deploy paths exist for ShelfAware:**
+>
+> 1. **Production (full system)** — the root [`deploy/install.sh`](../../deploy/install.sh)
+>    installs Process A, B, **and C** plus the orchestrator's systemd unit.
+>    The orchestrator decides at boot whether to launch Process C
+>    (offline / AP mode) or skip it (online / Process A + B mode).
+>    **This is what real Pi installs use.** See [`deploy/README.md`](../../deploy/README.md).
+> 2. **Standalone Process C (dev / test)** — the steps below. Useful for
+>    testing the HTTP API without booting the whole orchestrator state
+>    machine.
+> 3. **Foreground / interactive run** — same as #2 but with the venv
+>    pre-activated and stdout in your terminal. Best for live debugging.
+
+---
+
+## Prerequisites
+
+- Python 3.11+ (`python3 --version`)
+- `pip` and `venv` available
+- Linux box (most testing) or Windows (CI / unit tests only — `nmcli`
+  isn't available so the real WiFi switch will fail; use `SHELFAWARE_DEV=1`
+  to skip the real backend and let `RealWifiBackend` import lazily)
+- The repo cloned somewhere readable
+
+For the orchestrated production path additionally:
+- Raspberry Pi OS Bookworm (or other Debian-derivative with
+  `network-manager` installed)
+- `nmcli` working (`nmcli general status` should print without error)
+- A pre-configured AP profile named `ShelfAware_Setup` — the root
+  `deploy/install.sh` calls `orchestration/shelfaware_network_setup.sh`
+  to create it on first install
+
+---
+
+## Quick start: foreground / interactive run
+
+For development on your laptop or a Pi over Tailscale.
+
+```bash
+cd process-c
+python3 -m venv .venv
+source .venv/bin/activate                  # Linux / macOS
+# .\.venv\Scripts\Activate.ps1              # Windows PowerShell
+pip install -e '.[dev]'
+
+# Optional: copy and edit the env file (defaults are sensible for dev)
+cp deploy/process-c.env.example deploy/process-c.env
+$EDITOR deploy/process-c.env
+
+# Load env and run
+set -a; source deploy/process-c.env; set +a
+process-c
+```
+
+Equivalent direct invocation if you don't want the console script:
+`python3 -m process_c` or `python3 process_c.py`.
+
+You should see structured JSON logs on stdout, e.g.:
+
+```json
+{"ts":"2026-05-04T07:00:00Z","level":"INFO","logger":"process_c.main","msg":"process-c listening","bind_host":"0.0.0.0","bind_port":80}
+```
+
+Hit `Ctrl+C` to stop. Process C exits cleanly on `SIGINT`/`SIGTERM`.
+
+> [!WARNING]
+> Binding to port `80` requires root (`sudo`) on Linux. For dev runs use
+> `BIND_PORT=8080` (or any port >1024) in your env file.
+
+---
+
+## Environment variables
+
+| Variable | Default | Notes |
+|---|---|---|
+| `BIND_HOST` | `0.0.0.0` | Where the HTTP server listens. `127.0.0.1` for local-only testing. |
+| `BIND_PORT` | `80` | Use `8080` (or other >1024) for non-root dev runs. |
+| `DEVICE_FILE_PATH` | `/etc/shelfaware/device.json` | Provisioning state file. Process B reads this; Process C writes it. |
+| `ALLOW_RESET_ENDPOINT` | `false` | When `true`, exposes `POST /reset` (deletes `device.json`). Off in production. |
+| `LOG_LEVEL` | `INFO` | Standard `DEBUG` / `INFO` / `WARNING` / `ERROR` / `CRITICAL`. |
+| `SHELFAWARE_DEV` | `false` | When `true`, the real `wifi_connector` import is allowed to fail (so dev boxes without `nmcli` can still boot the server). |
+
+---
+
+## API surface
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/health` | Liveness + provisioning status (`already_provisioned: bool`). |
+| `POST` | `/provision` | Submit `{ssid, password, user_id}`. Writes `device.json`, returns `202` with the generated `shelf_id`, then fires the WiFi switch in the background. |
+| `POST` | `/reset` | (Opt-in) Deletes `device.json`. |
+| `OPTIONS` | `*` | CORS preflight. |
+
+CORS is enabled (`Access-Control-Allow-Origin: *`) because the companion
+app calls Process C from a browser context while connected to the Pi's
+hotspot.
+
+---
+
+## Running the test suite
+
+```bash
+cd process-c
+source .venv/bin/activate
+pytest -v
+```
+
+71 tests should pass. The suite uses `aiohttp.test_utils` for the HTTP
+handlers (no real socket binding) and a `FakeWifiBackend` so no `nmcli`
+calls happen.
+
+---
+
+## Deploying via the orchestrator (production)
+
+You almost never want to deploy Process C by itself in production.
+Instead, use the root installer which sets up everything:
+
+```bash
+sudo bash deploy/install.sh
+sudo systemctl start shelfaware-orchestrator
+journalctl -fu shelfaware-orchestrator
+```
+
+The orchestrator:
+1. Pings `8.8.8.8` on boot.
+2. If online → starts Process A + B (no Process C).
+3. If offline → switches to AP mode, starts Process B + **Process C**.
+4. When Process C calls `wifi_connector.apply_wifi_credentials`, the
+   orchestrator detects the connection change and re-runs the boot
+   decision.
+
+See [`deploy/README.md`](../../deploy/README.md) (root) and
+[`orchestration/orchestrator.py`](../../orchestration/orchestrator.py)
+for the full state machine.
+
+---
+
+## Troubleshooting
+
+**`OSError: [Errno 13] Permission denied` on bind**
+Port 80 needs root. Use `BIND_PORT=8080` for dev, or `sudo` it.
+
+**`OSError: [Errno 98] Address already in use`**
+Another Process C (or other server) is already on the port. Stop it
+first or pick a different port.
+
+**`ConfigError: DEVICE_FILE_PATH ... is not writeable`**
+The default `/etc/shelfaware/device.json` requires root. For dev runs
+point it somewhere else: `DEVICE_FILE_PATH=/tmp/device.json`.
+
+**`POST /provision` returns 500 with `{"error":"persistence"}`**
+`device.json` couldn't be written. Check disk space, permissions on
+`DEVICE_FILE_PATH`'s parent directory, and the structured log line right
+before the response — it includes the underlying `OSError`.
+
+**The WiFi switch never happens after a successful `POST /provision`**
+Process C returns `202` immediately and fires the switch in a
+background task. On dev machines without `nmcli` the
+`RealWifiBackend.apply_wifi_credentials` call will log an error and
+stop. That's expected — the server will accept the credentials and
+write `device.json`, but it can't actually change the network.
+
+**`POST /reset` returns 404**
+The endpoint is gated behind `ALLOW_RESET_ENDPOINT=true`. By design;
+flip it on intentionally for one-shot recovery, then off again.

--- a/process-c/deploy/process-c.env.example
+++ b/process-c/deploy/process-c.env.example
@@ -1,0 +1,23 @@
+# Process C environment file (example).
+# Copy to deploy/process-c.env and edit for your local dev setup.
+# Production values are baked into the orchestrator's systemd unit,
+# not this file.
+
+# HTTP server
+BIND_HOST=0.0.0.0
+BIND_PORT=8080                        # 80 in production (orchestrator runs as root)
+
+# Where Process C writes provisioning state.
+# Process B reads this same path to learn its shelf_id.
+# Production: /etc/shelfaware/device.json
+DEVICE_FILE_PATH=/tmp/shelfaware-device.json
+
+# Opt-in: when true, exposes POST /reset (deletes device.json).
+# Off by default. Flip on for one-shot recovery, then off again.
+ALLOW_RESET_ENDPOINT=false
+
+LOG_LEVEL=INFO
+
+# When true, the import of orchestration/wifi_connector.py is allowed to
+# fail (so dev boxes without nmcli can still boot the server).
+SHELFAWARE_DEV=true

--- a/process-c/process_c.py
+++ b/process-c/process_c.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Compatibility shim for the orchestrator.
+
+The orchestrator launches Process C with::
+
+    python3 /opt/shelfaware/process-c/process_c.py
+
+…which predates Process C being a real package. This file just forwards to
+:func:`process_c.main.run` so the orchestrator command line stays stable.
+
+If you're running Process C standalone, prefer the console script::
+
+    process-c
+
+or::
+
+    python3 -m process_c
+"""
+
+from __future__ import annotations
+
+from process_c.main import run
+
+if __name__ == "__main__":
+    run()

--- a/process-c/process_c/__init__.py
+++ b/process-c/process_c/__init__.py
@@ -1,0 +1,6 @@
+"""Process C — first-time setup HTTP server.
+
+See ``README.md`` in the package root for an overview.
+"""
+
+__version__ = "0.1.0"

--- a/process-c/process_c/config.py
+++ b/process-c/process_c/config.py
@@ -1,0 +1,117 @@
+"""Process C configuration loaded from environment variables.
+
+Mirrors Process B's :class:`process_b.config.Config` style: a frozen
+dataclass with a single :meth:`Config.from_env` classmethod that aggregates
+all validation errors into one :class:`ConfigError` so operators see every
+problem at once instead of fix-one-rerun cycles.
+
+Environment variables
+---------------------
+``BIND_HOST``               default ``0.0.0.0``     — interface to bind on
+``BIND_PORT``               default ``80``          — TCP port
+``DEVICE_FILE_PATH``        default ``/etc/shelfaware/device.json``
+``ALLOW_RESET_ENDPOINT``    default ``0``           — set ``1`` to expose POST /reset
+``LOG_LEVEL``               default ``INFO``        — Python logging level name
+``SHELFAWARE_DEV``          default ``0``           — set ``1`` to skip real WiFi switching
+
+In ``SHELFAWARE_DEV=1`` mode, the WiFi backend is mocked (no nmcli calls);
+this matches the convention used by the orchestrator and wifi_connector so
+a single env var enables dev mode for the whole stack.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+class ConfigError(Exception):
+    """Raised when one or more env vars are missing or malformed."""
+
+
+@dataclass(frozen=True)
+class Config:
+    bind_host: str
+    bind_port: int
+    device_file_path: str
+    allow_reset_endpoint: bool
+    log_level: str
+    dev_mode: bool
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> Config:
+        """Build a :class:`Config` from ``env`` (defaults to ``os.environ``).
+
+        Aggregates every validation problem and raises one
+        :class:`ConfigError` with a multi-line message at the end.
+        """
+        env = dict(os.environ) if env is None else env
+        errors: list[str] = []
+
+        bind_host = env.get("BIND_HOST", "0.0.0.0").strip() or "0.0.0.0"
+
+        bind_port = _parse_int(env, "BIND_PORT", default="80", errors=errors)
+        if bind_port is not None and not (1 <= bind_port <= 65535):
+            errors.append(f"BIND_PORT must be in 1..65535 (got {bind_port}).")
+
+        device_file_path = env.get(
+            "DEVICE_FILE_PATH", "/etc/shelfaware/device.json"
+        ).strip()
+        if not device_file_path:
+            errors.append("DEVICE_FILE_PATH must not be blank.")
+
+        allow_reset_endpoint = _parse_bool(
+            env, "ALLOW_RESET_ENDPOINT", default="0", errors=errors
+        )
+
+        log_level = env.get("LOG_LEVEL", "INFO").strip().upper() or "INFO"
+        if log_level not in {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}:
+            errors.append(
+                f"LOG_LEVEL must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL "
+                f"(got {log_level!r})."
+            )
+
+        dev_mode = _parse_bool(env, "SHELFAWARE_DEV", default="0", errors=errors)
+
+        if errors:
+            raise ConfigError(
+                "Process C configuration is invalid:\n  - " + "\n  - ".join(errors)
+            )
+
+        # mypy: bind_port and the bool helpers are guaranteed non-None here
+        # because errors would have populated above. cast via assert for typing.
+        assert bind_port is not None
+        assert allow_reset_endpoint is not None
+        assert dev_mode is not None
+
+        return cls(
+            bind_host=bind_host,
+            bind_port=bind_port,
+            device_file_path=device_file_path,
+            allow_reset_endpoint=allow_reset_endpoint,
+            log_level=log_level,
+            dev_mode=dev_mode,
+        )
+
+
+def _parse_int(
+    env: dict[str, str], key: str, *, default: str, errors: list[str]
+) -> int | None:
+    raw = env.get(key, default).strip() or default
+    try:
+        return int(raw)
+    except ValueError:
+        errors.append(f"{key} must be an integer (got {raw!r}).")
+        return None
+
+
+def _parse_bool(
+    env: dict[str, str], key: str, *, default: str, errors: list[str]
+) -> bool:
+    raw = env.get(key, default).strip().lower() or default
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off", ""}:
+        return False
+    errors.append(f"{key} must be 0/1/true/false (got {raw!r}).")
+    return False

--- a/process-c/process_c/device_state.py
+++ b/process-c/process_c/device_state.py
@@ -1,0 +1,175 @@
+"""Read/write the device provisioning file.
+
+Single source of truth for "is this Pi provisioned, and if so for whom?".
+Process C writes it on successful provisioning. Process B reads it at
+startup to learn its ``shelf_id`` and to register with the backend.
+
+File location is ``cfg.device_file_path`` (default
+``/etc/shelfaware/device.json``). Schema:
+
+.. code-block:: json
+
+   {
+     "user_id":        "<UUIDv4>",
+     "shelf_id":       "<UUIDv4>",
+     "provisioned_at": "<ISO 8601 UTC>",
+     "schema_version": 1
+   }
+
+``schema_version`` is a forward-compatibility hatch: if we ever need to
+change the file's shape, bumping this lets readers detect older formats
+and migrate.
+
+Atomic writes
+-------------
+Writes go to a sibling ``.tmp`` file then ``os.replace`` it onto the
+target path. ``os.replace`` is atomic on POSIX (and Windows for files on
+the same volume), so a reader can never observe a half-written file even
+if Process C is killed mid-write.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+
+class DeviceStateError(Exception):
+    """Raised when device.json exists but is malformed."""
+
+
+@dataclass(frozen=True)
+class DeviceState:
+    user_id: str
+    shelf_id: str
+    provisioned_at: str
+    schema_version: int = SCHEMA_VERSION
+
+
+def read(path: str | os.PathLike[str]) -> DeviceState | None:
+    """Return the persisted :class:`DeviceState`, or ``None`` if not provisioned.
+
+    Raises :class:`DeviceStateError` if the file exists but is malformed —
+    callers should treat that as a hard failure (don't silently re-provision
+    over corrupted data; an operator must look).
+    """
+    p = Path(path)
+    if not p.exists():
+        return None
+
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise DeviceStateError(f"could not read {p}: {exc}") from exc
+
+    try:
+        data: Any = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise DeviceStateError(f"{p} is not valid JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise DeviceStateError(f"{p} root must be a JSON object")
+
+    missing = [k for k in ("user_id", "shelf_id", "provisioned_at") if k not in data]
+    if missing:
+        raise DeviceStateError(f"{p} missing required fields: {missing}")
+
+    return DeviceState(
+        user_id=str(data["user_id"]),
+        shelf_id=str(data["shelf_id"]),
+        provisioned_at=str(data["provisioned_at"]),
+        schema_version=int(data.get("schema_version", SCHEMA_VERSION)),
+    )
+
+
+def write(path: str | os.PathLike[str], state: DeviceState) -> None:
+    """Atomically persist ``state`` to ``path``.
+
+    Creates the parent directory if missing (mode 750). The file itself is
+    written with mode 640 — readable by the orchestrator/Process B that
+    share the root-owned process tree, but not world-readable.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True, mode=0o750)
+
+    payload = {
+        "user_id":        state.user_id,
+        "shelf_id":       state.shelf_id,
+        "provisioned_at": state.provisioned_at,
+        "schema_version": state.schema_version,
+    }
+
+    # Write to a temp file in the same directory, then atomic-rename onto
+    # the target. Same-directory matters: os.replace requires same volume.
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".device-",
+        suffix=".json.tmp",
+        dir=str(p.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False)
+            f.flush()
+            os.fsync(f.fileno())
+        try:
+            os.chmod(tmp_path, 0o640)
+        except OSError:
+            # chmod is a no-op on Windows; tolerate it for cross-platform tests.
+            pass
+        os.replace(tmp_path, p)
+    except Exception:
+        # Best-effort cleanup of the temp file on any failure.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    logger.info(
+        "device.json written",
+        extra={"path": str(p), "shelf_id": state.shelf_id, "user_id": state.user_id},
+    )
+
+
+def delete(path: str | os.PathLike[str]) -> bool:
+    """Remove the device file. Returns ``True`` if a file was deleted.
+
+    Used by the (debug) ``POST /reset`` endpoint. Idempotent.
+    """
+    p = Path(path)
+    try:
+        p.unlink()
+    except FileNotFoundError:
+        return False
+    logger.warning("device.json deleted", extra={"path": str(p)})
+    return True
+
+
+def is_provisioned(path: str | os.PathLike[str]) -> bool:
+    """Convenience: ``True`` if a valid (or just-existing) device file is present.
+
+    Doesn't validate fields — see :func:`read` for that. The cheap check is
+    enough for ``GET /health`` and the orchestrator's "should I start
+    Process C?" decision.
+    """
+    return Path(path).exists()
+
+
+def make_state(user_id: str, shelf_id: str) -> DeviceState:
+    """Build a :class:`DeviceState` with a fresh ``provisioned_at`` timestamp."""
+    return DeviceState(
+        user_id=user_id,
+        shelf_id=shelf_id,
+        provisioned_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        schema_version=SCHEMA_VERSION,
+    )

--- a/process-c/process_c/handlers.py
+++ b/process-c/process_c/handlers.py
@@ -1,0 +1,199 @@
+"""HTTP handlers for the three Process C endpoints.
+
+The handlers are intentionally thin: validation lives in pydantic models,
+state mutation lives in :mod:`process_c.device_state`, and the actual
+WiFi work lives in :mod:`process_c.provisioner`. This keeps each handler
+under ~25 lines and makes them trivially unit-testable with a stub
+WifiBackend.
+
+Endpoints
+---------
+GET  /health
+    Used by the frontend to detect "I'm talking to a Pi in setup mode."
+    Always 200 OK; no auth.
+
+POST /provision
+    Body: ``{"ssid", "password", "user_id"}``. On success persists
+    device.json (with a freshly generated shelf_id) and schedules the
+    background WiFi switch. Returns 202 immediately.
+
+POST /reset
+    Wipes device.json. Disabled by default — only registered when
+    ``cfg.allow_reset_endpoint`` is true. Useful for dev / re-provisioning.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from aiohttp import web
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from process_c import __version__, device_state
+from process_c.config import Config
+from process_c.provisioner import schedule_provision
+from process_c.wifi_backend import WifiBackend
+
+logger = logging.getLogger(__name__)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Request / response models
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class ProvisionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ssid: str = Field(min_length=1, max_length=32)
+    password: str = Field(min_length=8, max_length=63)  # WPA2 PSK bounds
+    user_id: str = Field(min_length=1)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Handler factories
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# We build the handlers as closures over (cfg, wifi) rather than reaching
+# into request.app for them. Easier to test (just call the returned
+# coroutine with a fake Request) and avoids stringly-typed app["wifi"] keys.
+
+
+def make_health_handler(cfg: Config) -> Any:
+    async def health(request: web.Request) -> web.Response:
+        provisioned = device_state.is_provisioned(cfg.device_file_path)
+        return _json_response(
+            200,
+            {
+                "device": "shelfaware-pi",
+                "version": __version__,
+                "ready_for_provision": True,
+                "already_provisioned": provisioned,
+            },
+        )
+
+    return health
+
+
+def make_provision_handler(cfg: Config, wifi: WifiBackend) -> Any:
+    async def provision(request: web.Request) -> web.Response:
+        # Refuse if already provisioned — caller must hit /reset first.
+        # Frontend should check /health first, but defend anyway.
+        if device_state.is_provisioned(cfg.device_file_path):
+            return _json_response(
+                409,
+                {
+                    "error": "already_provisioned",
+                    "detail": "Device already has a device.json. POST /reset first.",
+                },
+            )
+
+        try:
+            raw = await request.json()
+        except ValueError:
+            return _json_response(
+                400, {"error": "validation", "detail": "Body must be valid JSON."}
+            )
+
+        try:
+            req = ProvisionRequest.model_validate(raw)
+        except ValidationError as exc:
+            return _json_response(
+                400,
+                {
+                    "error": "validation",
+                    "detail": exc.errors(include_url=False, include_input=False),
+                },
+            )
+
+        # Generate a fresh shelf_id locally so the Pi has a stable identity
+        # even if the backend is unreachable. Process B will register this
+        # with the backend at its next startup.
+        shelf_id = str(uuid.uuid4())
+        state = device_state.make_state(user_id=req.user_id, shelf_id=shelf_id)
+
+        try:
+            device_state.write(cfg.device_file_path, state)
+        except OSError as exc:
+            logger.exception("failed to write device.json")
+            return _json_response(
+                500,
+                {
+                    "error": "persistence",
+                    "detail": f"Could not write device file: {exc}",
+                },
+            )
+
+        # Spawn the WiFi switch in the background; do NOT await it.
+        # apply_wifi_credentials blocks for up to ~60s and once it succeeds
+        # the AP is gone, so the HTTP response can't reach the phone anyway.
+        schedule_provision(wifi, req.ssid, req.password)
+
+        logger.info(
+            "provision accepted",
+            extra={
+                "user_id": req.user_id,
+                "shelf_id": shelf_id,
+                "ssid": req.ssid,
+            },
+        )
+
+        return _json_response(
+            202,
+            {
+                "status": "accepted",
+                "shelf_id": shelf_id,
+            },
+        )
+
+    return provision
+
+
+def make_reset_handler(cfg: Config) -> Any:
+    async def reset(request: web.Request) -> web.Response:
+        deleted = device_state.delete(cfg.device_file_path)
+        return _json_response(
+            200,
+            {"status": "reset", "deleted": deleted},
+        )
+
+    return reset
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CORS
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@web.middleware
+async def cors_middleware(
+    request: web.Request, handler: Any
+) -> web.StreamResponse:
+    """Permissive CORS — captive-portal contexts have unpredictable origins.
+
+    Handles OPTIONS preflights inline so they don't reach handlers that
+    only support GET/POST.
+    """
+    if request.method == "OPTIONS":
+        return _cors_response(web.Response(status=204))
+
+    response = await handler(request)
+    return _cors_response(response)
+
+
+def _cors_response(response: web.StreamResponse) -> web.StreamResponse:
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
+    response.headers["Access-Control-Allow-Headers"] = "Content-Type"
+    return response
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _json_response(status: int, payload: dict[str, Any]) -> web.Response:
+    return web.json_response(payload, status=status)

--- a/process-c/process_c/logging_setup.py
+++ b/process-c/process_c/logging_setup.py
@@ -1,0 +1,76 @@
+"""Structured JSON logging for Process C.
+
+Same shape as :mod:`process_b.logging_setup` so logs from both daemons can
+be ingested by the same downstream tooling (journald + ``jq``).
+
+One JSON object per line, written to stdout. Fields:
+
+- ``ts``     — ISO 8601 UTC, millisecond precision
+- ``level``  — log level name
+- ``logger`` — logger name (e.g. ``process_c.handlers``)
+- ``msg``    — formatted message
+- any ``extra={}`` keys attached to the record (excluding stdlib reserved
+  attribute names so we don't double-stamp ``msg``, ``levelname`` etc.)
+- ``exc``    — formatted traceback, only present when ``exc_info`` is set
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+_RESERVED_LOGRECORD_ATTRS = frozenset(
+    {
+        "name", "msg", "args", "levelname", "levelno", "pathname", "filename",
+        "module", "exc_info", "exc_text", "stack_info", "lineno", "funcName",
+        "created", "msecs", "relativeCreated", "thread", "threadName",
+        "processName", "process", "message", "taskName",
+    }
+)
+
+
+class JsonFormatter(logging.Formatter):
+    """Render a :class:`logging.LogRecord` as a single JSON line."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        ts = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        payload: dict[str, Any] = {
+            "ts": ts.strftime("%Y-%m-%dT%H:%M:%S.") + f"{ts.microsecond // 1000:03d}Z",
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+
+        # Merge in any extra={} fields, skipping reserved LogRecord attrs.
+        for key, value in record.__dict__.items():
+            if key in _RESERVED_LOGRECORD_ATTRS or key.startswith("_"):
+                continue
+            if key in payload:
+                # Don't let extras overwrite our own reserved fields.
+                continue
+            payload[key] = value
+
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+
+        return json.dumps(payload, default=str, ensure_ascii=False)
+
+
+def configure(level: str = "INFO") -> None:
+    """Install a single stdout handler with :class:`JsonFormatter`.
+
+    Idempotent: replaces any existing handlers on the root logger so calling
+    twice does not produce duplicate lines.
+    """
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    for h in list(root.handlers):
+        root.removeHandler(h)
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(JsonFormatter())
+    root.addHandler(handler)

--- a/process-c/process_c/main.py
+++ b/process-c/process_c/main.py
@@ -1,0 +1,136 @@
+"""Process C entrypoint.
+
+Lifecycle::
+
+    1. Load Config from env.
+    2. Configure JSON logging.
+    3. Build the WifiBackend (FakeWifiBackend in dev mode, RealWifiBackend
+       in production).
+    4. Build the aiohttp Application with the three (or two) endpoints.
+    5. Start the HTTP server.
+    6. On SIGTERM/SIGINT: stop accepting new requests, let in-flight
+       requests drain, then exit.
+
+Configuration errors exit with code 2 so systemd's ``Restart=on-failure``
+distinguishes them from runtime issues (don't hot-loop on bad config).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import sys
+from typing import NoReturn
+
+from aiohttp import web
+
+from process_c import logging_setup
+from process_c.config import Config, ConfigError
+from process_c.handlers import (
+    cors_middleware,
+    make_health_handler,
+    make_provision_handler,
+    make_reset_handler,
+)
+from process_c.wifi_backend import FakeWifiBackend, RealWifiBackend, WifiBackend
+
+logger = logging.getLogger(__name__)
+
+
+def run() -> NoReturn:
+    """Console-script entrypoint declared in ``pyproject.toml``."""
+    try:
+        cfg = Config.from_env()
+    except ConfigError as exc:
+        sys.stderr.write(f"{exc}\n")
+        sys.exit(2)
+
+    logging_setup.configure(cfg.log_level)
+
+    try:
+        asyncio.run(_serve(cfg))
+    except KeyboardInterrupt:
+        logger.info("interrupted by user")
+        sys.exit(0)
+    sys.exit(0)
+
+
+async def _serve(cfg: Config) -> None:
+    wifi = _build_wifi_backend(cfg)
+    app = build_app(cfg, wifi)
+
+    runner = web.AppRunner(app, handle_signals=False)
+    await runner.setup()
+    site = web.TCPSite(runner, cfg.bind_host, cfg.bind_port)
+    await site.start()
+
+    logger.info(
+        "process-c listening",
+        extra={
+            "bind_host": cfg.bind_host,
+            "bind_port": cfg.bind_port,
+            "device_file_path": cfg.device_file_path,
+            "dev_mode": cfg.dev_mode,
+            "reset_endpoint": cfg.allow_reset_endpoint,
+        },
+    )
+
+    stop_event = _install_stop_event()
+    await stop_event.wait()
+
+    logger.info("process-c shutting down")
+    await runner.cleanup()
+
+
+def build_app(cfg: Config, wifi: WifiBackend) -> web.Application:
+    """Construct the aiohttp Application. Exposed for tests."""
+    app = web.Application(middlewares=[cors_middleware])
+
+    app.router.add_get("/health", make_health_handler(cfg))
+    app.router.add_post("/provision", make_provision_handler(cfg, wifi))
+
+    if cfg.allow_reset_endpoint:
+        app.router.add_post("/reset", make_reset_handler(cfg))
+        logger.warning(
+            "POST /reset endpoint is ENABLED — this should be off in production",
+            extra={"path": cfg.device_file_path},
+        )
+
+    return app
+
+
+def _build_wifi_backend(cfg: Config) -> WifiBackend:
+    if cfg.dev_mode:
+        logger.warning(
+            "[DEV MODE] using FakeWifiBackend — no real nmcli calls will be made"
+        )
+        return FakeWifiBackend()
+    return RealWifiBackend()
+
+
+def _install_stop_event() -> asyncio.Event:
+    """Set the returned event on SIGTERM/SIGINT so :func:`_serve` can exit."""
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _handler() -> None:
+        if not stop_event.is_set():
+            logger.info("signal received; initiating shutdown")
+            stop_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, _handler)
+        except (NotImplementedError, RuntimeError):
+            # Windows doesn't support add_signal_handler; tests/dev use
+            # KeyboardInterrupt-via-asyncio.run instead. Production runs
+            # on Linux where this works.
+            pass
+
+    return stop_event
+
+
+if __name__ == "__main__":
+    # Allows `python3 main.py` (orchestrator) and `process-c` (console script).
+    run()

--- a/process-c/process_c/provisioner.py
+++ b/process-c/process_c/provisioner.py
@@ -1,0 +1,100 @@
+"""Background provisioning task.
+
+POST /provision returns 202 immediately; the actual WiFi switch happens
+here, in a task spawned onto the event loop. This split is essential
+because :meth:`WifiBackend.apply_wifi_credentials` blocks for up to
+60 seconds, and once it succeeds the Pi has already left the AP — the
+HTTP response can't reach the phone any more anyway.
+
+Sequence
+--------
+1. Persist ``device.json`` (the bit Process B will read on its next start).
+2. Schedule the WiFi switch in a background task.
+3. Return control to the HTTP handler so it can send 202.
+4. The background task calls ``wifi_backend.apply_wifi_credentials`` in a
+   thread (it's a blocking, sync call) and logs the outcome.
+
+Errors during the background switch are logged loudly but never re-raised
+— at the point we're switching networks, there's nobody on the other end
+of the AP-mode HTTP connection to tell.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable
+
+from process_c.wifi_backend import ConnectResult, WifiBackend
+
+logger = logging.getLogger(__name__)
+
+# Type alias for the post-success hook (see schedule_provision below).
+PostSuccessHook = Callable[[], Awaitable[None]]
+
+
+async def perform_wifi_switch(
+    wifi: WifiBackend,
+    ssid: str,
+    password: str,
+    *,
+    timeout: int = 60,
+    on_success: PostSuccessHook | None = None,
+) -> ConnectResult:
+    """Run the (blocking) WiFi switch off-loop and log the outcome.
+
+    Returns the :class:`ConnectResult` so callers/tests can assert.
+    """
+    logger.info(
+        "wifi switch starting", extra={"ssid": ssid, "timeout": timeout}
+    )
+
+    try:
+        # apply_wifi_credentials blocks; offload to a thread.
+        result = await asyncio.to_thread(
+            wifi.apply_wifi_credentials, ssid, password, timeout
+        )
+    except Exception:
+        logger.exception("wifi switch raised; attempting rollback")
+        try:
+            await asyncio.to_thread(wifi.rollback_to_ap)
+        except Exception:
+            logger.exception("rollback also failed")
+        return ConnectResult.ERROR
+
+    if result == ConnectResult.SUCCESS:
+        logger.info("wifi switch succeeded", extra={"ssid": ssid})
+        if on_success is not None:
+            try:
+                await on_success()
+            except Exception:
+                logger.exception("post-success hook raised; ignoring")
+    else:
+        logger.warning(
+            "wifi switch did not succeed; backend has rolled back to AP",
+            extra={"ssid": ssid, "result": result.name},
+        )
+
+    return result
+
+
+def schedule_provision(
+    wifi: WifiBackend,
+    ssid: str,
+    password: str,
+    *,
+    timeout: int = 60,
+    on_success: PostSuccessHook | None = None,
+) -> asyncio.Task[ConnectResult]:
+    """Spawn :func:`perform_wifi_switch` as a fire-and-forget task.
+
+    Returns the :class:`asyncio.Task` so tests can await it. Production
+    callers (the HTTP handler) discard it.
+    """
+    task = asyncio.create_task(
+        perform_wifi_switch(
+            wifi, ssid, password, timeout=timeout, on_success=on_success
+        ),
+        name=f"wifi-switch-{ssid[:16]}",
+    )
+    return task

--- a/process-c/process_c/wifi_backend.py
+++ b/process-c/process_c/wifi_backend.py
@@ -1,0 +1,148 @@
+"""Pluggable WiFi-switching backend.
+
+Process C delegates the actual ``nmcli`` work to Anjinsan's
+``orchestration/wifi_connector.py``. That file is a script, not a package,
+which makes a direct import awkward. We hide the import behind a small
+:class:`WifiBackend` protocol so:
+
+- Tests can substitute :class:`FakeWifiBackend` with no monkeypatching of
+  module globals or sys.path.
+- The awkward ``sys.path`` insert lives in exactly one place
+  (:class:`RealWifiBackend`) and is only triggered when the real backend
+  is constructed.
+
+Why a Protocol rather than abstract base class
+-----------------------------------------------
+Structural typing (``Protocol``) means tests can pass a plain stub object
+without inheriting from anything. Lower friction.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from enum import Enum, auto
+from pathlib import Path
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectResult(Enum):
+    """Mirrors ``orchestration.wifi_connector.ConnectResult``.
+
+    Defined locally so callers don't need to know whether the underlying
+    enum comes from the real module or a fake.
+    """
+
+    SUCCESS = auto()
+    TIMEOUT = auto()
+    ERROR = auto()
+
+
+class WifiBackend(Protocol):
+    """Anything that can attempt a WiFi switch and (best-effort) roll back."""
+
+    def apply_wifi_credentials(
+        self, ssid: str, password: str, timeout: int = 60
+    ) -> ConnectResult:
+        ...
+
+    def rollback_to_ap(self) -> bool:
+        ...
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Real backend: imports orchestration/wifi_connector.py at construction time
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class RealWifiBackend:
+    """Production backend that delegates to ``orchestration/wifi_connector``.
+
+    The import is deferred to ``__init__`` (rather than module load) so that
+    importing :mod:`process_c.wifi_backend` is always cheap and side-effect
+    free, even on machines without ``nmcli`` (developer laptops, CI).
+    """
+
+    def __init__(self, orchestration_dir: str | os.PathLike[str] | None = None) -> None:
+        self._wc = self._import_wifi_connector(orchestration_dir)
+
+    @staticmethod
+    def _import_wifi_connector(
+        orchestration_dir: str | os.PathLike[str] | None,
+    ) -> object:
+        # Default candidates, in order of plausibility:
+        # 1. /opt/shelfaware/orchestration  (production install path)
+        # 2. <repo>/orchestration           (dev mode: ../orchestration)
+        candidates: list[Path] = []
+        if orchestration_dir is not None:
+            candidates.append(Path(orchestration_dir))
+        candidates.append(Path("/opt/shelfaware/orchestration"))
+        # Repo layout: process-c/process_c/wifi_backend.py → ../../orchestration
+        candidates.append(Path(__file__).resolve().parent.parent.parent / "orchestration")
+
+        for d in candidates:
+            if (d / "wifi_connector.py").exists():
+                if str(d) not in sys.path:
+                    sys.path.insert(0, str(d))
+                import wifi_connector  # noqa: PLC0415  (intentional deferred import)
+
+                logger.info(
+                    "loaded real wifi_connector",
+                    extra={"orchestration_dir": str(d)},
+                )
+                return wifi_connector
+
+        raise RuntimeError(
+            "wifi_connector.py not found in any of: "
+            + ", ".join(str(c) for c in candidates)
+            + ". Set orchestration_dir explicitly, or use FakeWifiBackend."
+        )
+
+    def apply_wifi_credentials(
+        self, ssid: str, password: str, timeout: int = 60
+    ) -> ConnectResult:
+        # The wifi_connector module exposes its own ConnectResult enum;
+        # translate by name so we stay decoupled.
+        result = self._wc.apply_wifi_credentials(ssid, password, timeout=timeout)  # type: ignore[attr-defined]
+        return ConnectResult[result.name]
+
+    def rollback_to_ap(self) -> bool:
+        ok: bool = self._wc.rollback_to_ap()  # type: ignore[attr-defined]
+        return ok
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fake backend: for tests and SHELFAWARE_DEV=1 mode
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class FakeWifiBackend:
+    """In-memory fake — never touches the network.
+
+    Default behaviour: every ``apply_wifi_credentials`` call returns
+    :attr:`ConnectResult.SUCCESS`. Tests can override
+    :attr:`next_result` to drive failure paths.
+    """
+
+    def __init__(self, *, next_result: ConnectResult = ConnectResult.SUCCESS) -> None:
+        self.next_result = next_result
+        self.calls: list[tuple[str, str, int]] = []
+        self.rollback_calls: int = 0
+
+    def apply_wifi_credentials(
+        self, ssid: str, password: str, timeout: int = 60
+    ) -> ConnectResult:
+        self.calls.append((ssid, password, timeout))
+        logger.info(
+            "[fake wifi] apply_wifi_credentials called",
+            extra={"ssid": ssid, "timeout": timeout, "result": self.next_result.name},
+        )
+        return self.next_result
+
+    def rollback_to_ap(self) -> bool:
+        self.rollback_calls += 1
+        logger.info("[fake wifi] rollback_to_ap called")
+        return True

--- a/process-c/pyproject.toml
+++ b/process-c/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "process-c"
+version = "0.1.0"
+description = "ShelfAware Process C — first-time setup HTTP server (AP-mode provisioning daemon)."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "ShelfAware" }]
+
+dependencies = [
+    "aiohttp>=3.9,<4.0",
+    "pydantic>=2.7,<3.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.2",
+    "pytest-asyncio>=0.23",
+    "ruff>=0.6",
+    "mypy>=1.11",
+]
+
+[project.scripts]
+process-c = "process_c.main:run"
+
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["process_c"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-ra"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "UP",  # pyupgrade
+    "SIM", # flake8-simplify
+    "RUF",
+]
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.mypy]
+python_version = "3.11"
+disallow_untyped_defs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_return_any = true
+no_implicit_optional = true
+files = ["process_c", "tests"]
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false

--- a/process-c/tests/test_config.py
+++ b/process-c/tests/test_config.py
@@ -1,0 +1,96 @@
+"""Tests for :mod:`process_c.config`."""
+
+from __future__ import annotations
+
+import pytest
+
+from process_c.config import Config, ConfigError
+
+
+class TestFromEnvHappyPath:
+    def test_all_defaults(self) -> None:
+        cfg = Config.from_env(env={})
+        assert cfg.bind_host == "0.0.0.0"
+        assert cfg.bind_port == 80
+        assert cfg.device_file_path == "/etc/shelfaware/device.json"
+        assert cfg.allow_reset_endpoint is False
+        assert cfg.log_level == "INFO"
+        assert cfg.dev_mode is False
+
+    def test_full_overrides(self) -> None:
+        cfg = Config.from_env(
+            env={
+                "BIND_HOST": "127.0.0.1",
+                "BIND_PORT": "8080",
+                "DEVICE_FILE_PATH": "/tmp/device.json",
+                "ALLOW_RESET_ENDPOINT": "1",
+                "LOG_LEVEL": "DEBUG",
+                "SHELFAWARE_DEV": "1",
+            }
+        )
+        assert cfg.bind_host == "127.0.0.1"
+        assert cfg.bind_port == 8080
+        assert cfg.device_file_path == "/tmp/device.json"
+        assert cfg.allow_reset_endpoint is True
+        assert cfg.log_level == "DEBUG"
+        assert cfg.dev_mode is True
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("1", True), ("true", True), ("True", True), ("YES", True), ("on", True),
+            ("0", False), ("false", False), ("FALSE", False), ("no", False), ("off", False),
+        ],
+    )
+    def test_bool_parses_common_aliases(self, raw: str, expected: bool) -> None:
+        cfg = Config.from_env(env={"SHELFAWARE_DEV": raw})
+        assert cfg.dev_mode is expected
+
+    def test_log_level_uppercased(self) -> None:
+        cfg = Config.from_env(env={"LOG_LEVEL": "debug"})
+        assert cfg.log_level == "DEBUG"
+
+    def test_blank_bind_host_falls_back_to_default(self) -> None:
+        cfg = Config.from_env(env={"BIND_HOST": "   "})
+        assert cfg.bind_host == "0.0.0.0"
+
+
+class TestFromEnvErrors:
+    def test_invalid_port_string(self) -> None:
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(env={"BIND_PORT": "not-a-number"})
+        assert "BIND_PORT" in str(exc.value)
+
+    def test_port_out_of_range(self) -> None:
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(env={"BIND_PORT": "70000"})
+        assert "1..65535" in str(exc.value)
+
+    def test_port_zero_rejected(self) -> None:
+        with pytest.raises(ConfigError):
+            Config.from_env(env={"BIND_PORT": "0"})
+
+    def test_blank_device_file_path(self) -> None:
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(env={"DEVICE_FILE_PATH": "   "})
+        assert "DEVICE_FILE_PATH" in str(exc.value)
+
+    def test_invalid_log_level(self) -> None:
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(env={"LOG_LEVEL": "TRACE"})
+        assert "LOG_LEVEL" in str(exc.value)
+
+    def test_invalid_bool(self) -> None:
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(env={"SHELFAWARE_DEV": "maybe"})
+        assert "SHELFAWARE_DEV" in str(exc.value)
+
+    def test_multiple_errors_aggregated(self) -> None:
+        with pytest.raises(ConfigError) as exc:
+            Config.from_env(
+                env={"BIND_PORT": "abc", "LOG_LEVEL": "TRACE", "SHELFAWARE_DEV": "x"}
+            )
+        msg = str(exc.value)
+        assert "BIND_PORT" in msg
+        assert "LOG_LEVEL" in msg
+        assert "SHELFAWARE_DEV" in msg

--- a/process-c/tests/test_device_state.py
+++ b/process-c/tests/test_device_state.py
@@ -1,0 +1,127 @@
+"""Tests for :mod:`process_c.device_state`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from process_c import device_state
+from process_c.device_state import DeviceState, DeviceStateError, make_state
+
+
+@pytest.fixture
+def device_path(tmp_path: Path) -> Path:
+    return tmp_path / "device.json"
+
+
+class TestRead:
+    def test_returns_none_when_file_missing(self, device_path: Path) -> None:
+        assert device_state.read(device_path) is None
+
+    def test_returns_state_for_well_formed_file(self, device_path: Path) -> None:
+        device_path.write_text(
+            json.dumps(
+                {
+                    "user_id": "u1",
+                    "shelf_id": "s1",
+                    "provisioned_at": "2026-05-04T07:00:00Z",
+                    "schema_version": 1,
+                }
+            )
+        )
+        result = device_state.read(device_path)
+        assert result == DeviceState(
+            user_id="u1",
+            shelf_id="s1",
+            provisioned_at="2026-05-04T07:00:00Z",
+            schema_version=1,
+        )
+
+    def test_raises_when_not_json(self, device_path: Path) -> None:
+        device_path.write_text("not json")
+        with pytest.raises(DeviceStateError) as exc:
+            device_state.read(device_path)
+        assert "JSON" in str(exc.value)
+
+    def test_raises_when_root_is_not_object(self, device_path: Path) -> None:
+        device_path.write_text("[1, 2, 3]")
+        with pytest.raises(DeviceStateError):
+            device_state.read(device_path)
+
+    def test_raises_when_required_field_missing(self, device_path: Path) -> None:
+        device_path.write_text(json.dumps({"user_id": "u", "shelf_id": "s"}))
+        with pytest.raises(DeviceStateError) as exc:
+            device_state.read(device_path)
+        assert "provisioned_at" in str(exc.value)
+
+    def test_default_schema_version_when_missing(self, device_path: Path) -> None:
+        # schema_version is the only optional field; tolerate older writers.
+        device_path.write_text(
+            json.dumps(
+                {"user_id": "u", "shelf_id": "s", "provisioned_at": "2026-01-01T00:00:00Z"}
+            )
+        )
+        state = device_state.read(device_path)
+        assert state is not None
+        assert state.schema_version == 1
+
+
+class TestWrite:
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "device.json"
+        device_state.write(nested, make_state("u", "s"))
+        assert nested.exists()
+
+    def test_round_trips(self, device_path: Path) -> None:
+        original = make_state("user-uuid", "shelf-uuid")
+        device_state.write(device_path, original)
+        loaded = device_state.read(device_path)
+        assert loaded == original
+
+    def test_overwrites_existing_atomically(self, device_path: Path) -> None:
+        device_state.write(device_path, make_state("u1", "s1"))
+        device_state.write(device_path, make_state("u2", "s2"))
+
+        loaded = device_state.read(device_path)
+        assert loaded is not None
+        assert loaded.user_id == "u2"
+        assert loaded.shelf_id == "s2"
+
+    def test_no_temp_file_left_behind(self, tmp_path: Path) -> None:
+        device_state.write(tmp_path / "device.json", make_state("u", "s"))
+        leftover = list(tmp_path.glob(".device-*.json.tmp"))
+        assert leftover == []
+
+
+class TestDelete:
+    def test_returns_true_when_file_existed(self, device_path: Path) -> None:
+        device_state.write(device_path, make_state("u", "s"))
+        assert device_state.delete(device_path) is True
+        assert not device_path.exists()
+
+    def test_returns_false_when_no_file(self, device_path: Path) -> None:
+        assert device_state.delete(device_path) is False
+
+
+class TestIsProvisioned:
+    def test_false_when_missing(self, device_path: Path) -> None:
+        assert device_state.is_provisioned(device_path) is False
+
+    def test_true_when_present_even_if_malformed(self, device_path: Path) -> None:
+        # is_provisioned is the cheap check — it doesn't validate fields.
+        # That's by design: callers that need validation use read().
+        device_path.write_text("garbage")
+        assert device_state.is_provisioned(device_path) is True
+
+
+class TestMakeState:
+    def test_stamps_provisioned_at(self) -> None:
+        state = make_state("u", "s")
+        # Roughly ISO 8601 UTC; we don't pin exact format here.
+        assert state.provisioned_at.endswith("Z")
+        assert "T" in state.provisioned_at
+        assert state.user_id == "u"
+        assert state.shelf_id == "s"
+        assert state.schema_version == 1

--- a/process-c/tests/test_handlers.py
+++ b/process-c/tests/test_handlers.py
@@ -1,0 +1,238 @@
+"""Tests for :mod:`process_c.handlers`.
+
+Uses ``aiohttp.test_utils`` to spin up the real ``web.Application`` against
+an ephemeral port and hit it with the bundled test client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from aiohttp.test_utils import TestClient, TestServer
+
+from process_c import device_state
+from process_c.config import Config
+from process_c.main import build_app
+from process_c.wifi_backend import ConnectResult, FakeWifiBackend
+
+
+def _cfg(device_path: Path, *, allow_reset: bool = False) -> Config:
+    return Config(
+        bind_host="127.0.0.1",
+        bind_port=0,
+        device_file_path=str(device_path),
+        allow_reset_endpoint=allow_reset,
+        log_level="DEBUG",
+        dev_mode=True,
+    )
+
+
+@pytest_asyncio.fixture
+async def make_client():
+    """Returns a factory that builds a TestClient for a given (cfg, wifi)."""
+    clients: list[TestClient] = []
+
+    async def factory(cfg: Config, wifi: FakeWifiBackend) -> TestClient:
+        app = build_app(cfg, wifi)
+        client = TestClient(TestServer(app))
+        await client.start_server()
+        clients.append(client)
+        return client
+
+    yield factory
+
+    for c in clients:
+        await c.close()
+
+
+class TestHealth:
+    async def test_returns_device_descriptor(self, tmp_path: Path, make_client) -> None:
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.get("/health")
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["device"] == "shelfaware-pi"
+        assert body["ready_for_provision"] is True
+        assert body["already_provisioned"] is False
+
+    async def test_already_provisioned_when_file_present(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        device_path = tmp_path / "device.json"
+        device_state.write(device_path, device_state.make_state("u", "s"))
+
+        cfg = _cfg(device_path)
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.get("/health")
+        body = await resp.json()
+        assert body["already_provisioned"] is True
+
+    async def test_cors_headers_present(self, tmp_path: Path, make_client) -> None:
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.get("/health")
+        assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+
+    async def test_options_preflight(self, tmp_path: Path, make_client) -> None:
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.options("/provision")
+        assert resp.status == 204
+        assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+
+
+class TestProvision:
+    async def test_happy_path_writes_device_json_and_returns_202(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        device_path = tmp_path / "device.json"
+        cfg = _cfg(device_path)
+        wifi = FakeWifiBackend(next_result=ConnectResult.SUCCESS)
+        client = await make_client(cfg, wifi)
+
+        resp = await client.post(
+            "/provision",
+            json={
+                "ssid": "MyHomeWiFi",
+                "password": "hunter2-strong",
+                "user_id": "user-uuid-1",
+            },
+        )
+        assert resp.status == 202
+        body = await resp.json()
+        assert body["status"] == "accepted"
+        assert isinstance(body["shelf_id"], str) and len(body["shelf_id"]) >= 32
+
+        # device.json must exist with the user_id and matching shelf_id
+        loaded = device_state.read(device_path)
+        assert loaded is not None
+        assert loaded.user_id == "user-uuid-1"
+        assert loaded.shelf_id == body["shelf_id"]
+
+        # The background WiFi switch should fire — give it a moment.
+        for _ in range(20):
+            if wifi.calls:
+                break
+            await asyncio.sleep(0.01)
+        assert wifi.calls, "wifi backend was never called"
+        assert wifi.calls[0][0] == "MyHomeWiFi"
+        assert wifi.calls[0][1] == "hunter2-strong"
+
+    async def test_409_when_already_provisioned(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        device_path = tmp_path / "device.json"
+        device_state.write(device_path, device_state.make_state("u", "s"))
+
+        cfg = _cfg(device_path)
+        wifi = FakeWifiBackend()
+        client = await make_client(cfg, wifi)
+
+        resp = await client.post(
+            "/provision",
+            json={"ssid": "x", "password": "12345678", "user_id": "u2"},
+        )
+        assert resp.status == 409
+        body = await resp.json()
+        assert body["error"] == "already_provisioned"
+        assert wifi.calls == []
+
+    async def test_400_on_invalid_json(self, tmp_path: Path, make_client) -> None:
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.post("/provision", data="not json")
+        assert resp.status == 400
+        body = await resp.json()
+        assert body["error"] == "validation"
+
+    @pytest.mark.parametrize(
+        "payload,reason",
+        [
+            ({}, "all fields missing"),
+            ({"ssid": "x"}, "missing password and user_id"),
+            ({"ssid": "x", "password": "12345678"}, "missing user_id"),
+            ({"ssid": "", "password": "12345678", "user_id": "u"}, "empty ssid"),
+            ({"ssid": "x", "password": "short", "user_id": "u"}, "password too short"),
+            (
+                {"ssid": "x", "password": "12345678", "user_id": "u", "extra": True},
+                "extra field forbidden",
+            ),
+        ],
+    )
+    async def test_400_on_validation_failures(
+        self, tmp_path: Path, make_client, payload: dict, reason: str
+    ) -> None:
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.post("/provision", json=payload)
+        assert resp.status == 400, f"expected 400 for: {reason}"
+        body = await resp.json()
+        assert body["error"] == "validation"
+
+    async def test_500_when_device_file_unwriteable(
+        self, tmp_path: Path, make_client, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        def boom(*args: object, **kwargs: object) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(device_state, "write", boom)
+
+        resp = await client.post(
+            "/provision",
+            json={"ssid": "x", "password": "12345678", "user_id": "u"},
+        )
+        assert resp.status == 500
+        body = await resp.json()
+        assert body["error"] == "persistence"
+
+
+class TestReset:
+    async def test_route_not_registered_when_disabled(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        cfg = _cfg(tmp_path / "device.json", allow_reset=False)
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.post("/reset")
+        assert resp.status == 404
+
+    async def test_deletes_device_file_when_enabled(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        device_path = tmp_path / "device.json"
+        device_state.write(device_path, device_state.make_state("u", "s"))
+
+        cfg = _cfg(device_path, allow_reset=True)
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.post("/reset")
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["deleted"] is True
+        assert not device_path.exists()
+
+    async def test_reset_idempotent_when_no_file(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        cfg = _cfg(tmp_path / "device.json", allow_reset=True)
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.post("/reset")
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["deleted"] is False

--- a/process-c/tests/test_logging_setup.py
+++ b/process-c/tests/test_logging_setup.py
@@ -1,0 +1,98 @@
+"""Tests for :mod:`process_c.logging_setup`."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import sys
+
+import pytest
+
+from process_c import logging_setup
+from process_c.logging_setup import JsonFormatter
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging() -> None:
+    """Make sure each test starts with no leftover handlers."""
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    yield
+    for h in list(root.handlers):
+        root.removeHandler(h)
+
+
+def test_format_emits_one_json_line() -> None:
+    record = logging.LogRecord(
+        name="process_c.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello %s",
+        args=("world",),
+        exc_info=None,
+    )
+    out = JsonFormatter().format(record)
+    assert "\n" not in out
+    payload = json.loads(out)
+    assert payload["msg"] == "hello world"
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "process_c.test"
+    assert payload["ts"].endswith("Z")
+
+
+def test_extra_fields_are_merged() -> None:
+    record = logging.LogRecord(
+        name="x", level=logging.INFO, pathname="", lineno=0,
+        msg="m", args=(), exc_info=None,
+    )
+    record.shelf_id = "abc"  # how logging.Logger.makeRecord injects extras
+    record.attempt = 3
+
+    payload = json.loads(JsonFormatter().format(record))
+    assert payload["shelf_id"] == "abc"
+    assert payload["attempt"] == 3
+
+
+def test_extra_does_not_overwrite_reserved() -> None:
+    record = logging.LogRecord(
+        name="x", level=logging.INFO, pathname="", lineno=0,
+        msg="real", args=(), exc_info=None,
+    )
+    # Try to inject a "level" field via extra; formatter should ignore it.
+    record.level = "EMERGENCY"  # type: ignore[assignment]
+    payload = json.loads(JsonFormatter().format(record))
+    assert payload["level"] == "INFO"
+
+
+def test_exception_appears_under_exc_key() -> None:
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        record = logging.LogRecord(
+            name="x", level=logging.ERROR, pathname="", lineno=0,
+            msg="oops", args=(), exc_info=sys.exc_info(),
+        )
+    payload = json.loads(JsonFormatter().format(record))
+    assert "exc" in payload
+    assert "ValueError" in payload["exc"]
+    assert "boom" in payload["exc"]
+
+
+def test_configure_is_idempotent() -> None:
+    logging_setup.configure("INFO")
+    first = logging.getLogger().handlers[:]
+    logging_setup.configure("INFO")
+    second = logging.getLogger().handlers[:]
+    # Same number of handlers; not duplicated.
+    assert len(second) == len(first) == 1
+
+
+def test_configure_writes_to_stdout(capsys: pytest.CaptureFixture[str]) -> None:
+    logging_setup.configure("INFO")
+    logging.getLogger("process_c.test").info("smoke")
+    out = capsys.readouterr().out
+    payload = json.loads(out.strip())
+    assert payload["msg"] == "smoke"

--- a/process-c/tests/test_provisioner.py
+++ b/process-c/tests/test_provisioner.py
@@ -1,0 +1,103 @@
+"""Tests for :mod:`process_c.provisioner`."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from process_c.provisioner import perform_wifi_switch, schedule_provision
+from process_c.wifi_backend import ConnectResult, FakeWifiBackend
+
+
+class _RaisingBackend(FakeWifiBackend):
+    def apply_wifi_credentials(
+        self, ssid: str, password: str, timeout: int = 60
+    ) -> ConnectResult:
+        raise RuntimeError("nmcli exploded")
+
+
+class TestPerformWifiSwitch:
+    async def test_success_passes_args_and_returns_result(self) -> None:
+        wifi = FakeWifiBackend(next_result=ConnectResult.SUCCESS)
+        result = await perform_wifi_switch(wifi, "MyWifi", "hunter22", timeout=30)
+        assert result == ConnectResult.SUCCESS
+        assert wifi.calls == [("MyWifi", "hunter22", 30)]
+
+    async def test_timeout_result_is_returned(self) -> None:
+        wifi = FakeWifiBackend(next_result=ConnectResult.TIMEOUT)
+        result = await perform_wifi_switch(wifi, "ssid", "password")
+        assert result == ConnectResult.TIMEOUT
+
+    async def test_exception_triggers_rollback_and_returns_error(self) -> None:
+        wifi = _RaisingBackend()
+        result = await perform_wifi_switch(wifi, "ssid", "password")
+        assert result == ConnectResult.ERROR
+        assert wifi.rollback_calls == 1
+
+    async def test_on_success_hook_called_only_when_success(self) -> None:
+        called = asyncio.Event()
+
+        async def hook() -> None:
+            called.set()
+
+        wifi = FakeWifiBackend(next_result=ConnectResult.SUCCESS)
+        await perform_wifi_switch(wifi, "s", "password", on_success=hook)
+        assert called.is_set()
+
+        called.clear()
+        wifi = FakeWifiBackend(next_result=ConnectResult.TIMEOUT)
+        await perform_wifi_switch(wifi, "s", "password", on_success=hook)
+        assert not called.is_set()
+
+    async def test_on_success_hook_exception_is_swallowed(self) -> None:
+        async def bad_hook() -> None:
+            raise RuntimeError("boom")
+
+        wifi = FakeWifiBackend(next_result=ConnectResult.SUCCESS)
+        # Should not raise:
+        result = await perform_wifi_switch(wifi, "s", "password", on_success=bad_hook)
+        assert result == ConnectResult.SUCCESS
+
+
+class TestScheduleProvision:
+    async def test_returns_awaitable_task(self) -> None:
+        wifi = FakeWifiBackend()
+        task = schedule_provision(wifi, "ssid", "password")
+        assert isinstance(task, asyncio.Task)
+        result = await task
+        assert result == ConnectResult.SUCCESS
+
+    async def test_task_name_includes_ssid_prefix(self) -> None:
+        wifi = FakeWifiBackend()
+        task = schedule_provision(wifi, "MyHomeWiFi-2026", "password")
+        try:
+            assert "MyHomeWiFi" in task.get_name()
+        finally:
+            await task
+
+    async def test_does_not_block_caller(self) -> None:
+        # If schedule_provision were synchronous, this whole thing would
+        # take >0.1s; instead it must return immediately.
+        wifi = FakeWifiBackend()
+
+        # Inject artificial delay into the backend so we can observe it:
+        original = wifi.apply_wifi_credentials
+
+        def slow(ssid: str, password: str, timeout: int = 60) -> ConnectResult:
+            import time as _t
+            _t.sleep(0.1)
+            return original(ssid, password, timeout)
+
+        wifi.apply_wifi_credentials = slow  # type: ignore[method-assign]
+
+        loop = asyncio.get_running_loop()
+        t0 = loop.time()
+        task = schedule_provision(wifi, "s", "password")
+        elapsed_to_schedule = loop.time() - t0
+
+        assert elapsed_to_schedule < 0.05, (
+            f"schedule_provision blocked for {elapsed_to_schedule:.3f}s"
+        )
+
+        await task  # let it finish so pytest doesn't warn

--- a/process-c/tests/test_wifi_backend.py
+++ b/process-c/tests/test_wifi_backend.py
@@ -1,0 +1,40 @@
+"""Tests for :mod:`process_c.wifi_backend`.
+
+Only :class:`FakeWifiBackend` is exercised here. :class:`RealWifiBackend`
+is integration-tested implicitly via end-to-end runs on the Pi — unit
+testing it would require either a real ``nmcli`` or extensive mocking of
+the dynamic import dance, neither of which is worth it.
+"""
+
+from __future__ import annotations
+
+from process_c.wifi_backend import ConnectResult, FakeWifiBackend
+
+
+class TestFakeWifiBackend:
+    def test_default_returns_success(self) -> None:
+        wifi = FakeWifiBackend()
+        result = wifi.apply_wifi_credentials("ssid", "password")
+        assert result == ConnectResult.SUCCESS
+
+    def test_records_calls(self) -> None:
+        wifi = FakeWifiBackend()
+        wifi.apply_wifi_credentials("ssid1", "password1", timeout=30)
+        wifi.apply_wifi_credentials("ssid2", "password2")
+        assert wifi.calls == [
+            ("ssid1", "password1", 30),
+            ("ssid2", "password2", 60),
+        ]
+
+    def test_can_be_configured_to_return_other_results(self) -> None:
+        wifi = FakeWifiBackend(next_result=ConnectResult.TIMEOUT)
+        assert wifi.apply_wifi_credentials("s", "p") == ConnectResult.TIMEOUT
+
+        wifi.next_result = ConnectResult.ERROR
+        assert wifi.apply_wifi_credentials("s", "p") == ConnectResult.ERROR
+
+    def test_rollback_returns_true_and_counts(self) -> None:
+        wifi = FakeWifiBackend()
+        assert wifi.rollback_to_ap() is True
+        assert wifi.rollback_to_ap() is True
+        assert wifi.rollback_calls == 2


### PR DESCRIPTION
## Related Issue / User Story and BRIEFLY explain what you have done/changed and where

Link the issue or user story this PR belongs to:

- Closes # [Insert Issue Number]
- Merges initial orchestration branch, Process C/B wiring, and Process A CPU/Trigger optimizations.

**What was done/changed:**
This PR completes the orchestration layer and device provisioning flow, while optimizing the main sensor process. 

1. **Orchestration & Infrastructure:** - Added `orchestrator.py` to handle boot decisions (online vs. offline AP mode).
   - Added `wifi_connector.py` with a 60s rollback mechanism for failed credentials.
   - Added deployment scripts and hardened the systemd unit.

2. **Process A (Optimizations):** - Upgraded to support dual-zone sensors.
   - Implemented dynamic CPU scaling (performance mode when active, ondemand when idle).
   - Switched from presence-based polling to delta-based activity triggers (15g threshold) to improve efficiency.

3. **Process C (Provisioning):** - Created a new aiohttp daemon running in AP mode to accept WiFi credentials and user IDs.
   - Added atomic writing for `/etc/shelfaware/device.json`.

4. **Process B (Registration):** - Wired to read from `device.json`.
   - Added `registrar.py` to automatically register the shelf with the backend using bounded exponential backoff for fault tolerance.

---

## Type of change

- [x] New feature (User Story implementation)
- [x] Task (part of a user story)
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation update

---

## Tested?
- [x] Manual testing done locally except for nmcli

## Notes:
CPU scaling, sensor polling, and orchestrator boot paths were verified on physical Pi 4B hardware. Process C has 71 passing automated tests. 

---

## Checklist before requesting review
Not applicable

---

## Notes for reviewers

Anything reviewers should focus on:

- **Backend Integration:** The `POST /shelves` endpoint is not yet implemented on the backend. The `registrar.py` will log backoff warnings until this endpoint is live.
- **Process A Config:** Process A still uses a hardcoded `SHELF_ID`. A follow-up PR is required to wire it to read from the new `/etc/shelfaware/device.json` file.