### PR TITLE
feat(process-c): add captive portal landing page + form-encoded /prov…

### DIFF
--- a/process-c/README.md
+++ b/process-c/README.md
@@ -27,11 +27,31 @@ when it switches to online mode.
 
 ## Endpoints
 
-| Method | Path        | Purpose                                    |
-| ------ | ----------- | ------------------------------------------ |
-| GET    | `/health`   | Frontend probe to detect "I'm on a Pi"     |
-| POST   | `/provision`| Submit WiFi creds + user_id                |
-| POST   | `/reset`    | (debug) wipe device.json — disabled by default |
+| Method | Path                          | Purpose                                                              |
+| ------ | ----------------------------- | -------------------------------------------------------------------- |
+| GET    | `/`                           | Captive-portal landing page (HTML credential form)                   |
+| GET    | `/health`                     | Frontend probe to detect "I'm on a Pi"                               |
+| POST   | `/provision`                  | Submit WiFi creds + user_id (JSON or form-encoded)                   |
+| POST   | `/reset`                      | (debug) wipe device.json — disabled by default                       |
+| GET    | `/generate_204`, `/gen_204`   | Android captive-portal probe                                         |
+| GET    | `/hotspot-detect.html` (+ variant) | iOS / macOS captive-portal probe                                |
+| GET    | `/ncsi.txt`, `/connecttest.txt`    | Windows captive-portal probe                                    |
+
+There are two ways for a client to drive `POST /provision`:
+
+- **JSON** (`Content-Type: application/json`) — used by the in-page
+  JavaScript and by native apps / curl. Returns `202` with a JSON body
+  `{"status":"accepted","shelf_id":"..."}` on success.
+- **Form-encoded** (`Content-Type: application/x-www-form-urlencoded`)
+  — used as the no-JS fallback when the user submits the HTML form
+  directly. Returns the same `202` but renders an HTML success page so
+  the user sees a friendly confirmation rather than raw JSON.
+
+The captive-portal probes deliberately **fail** each OS's "is there real
+internet?" check so that, when paired with AP-side DNS hijacking (in
+`shelfaware_network_setup.sh`), the OS auto-pops its captive-portal
+browser pointed at `/`. Without DNS hijacking the probes are dead code —
+the OS never reaches them — but they're cheap to keep ready.
 
 See `process_c/handlers.py` for full request/response schemas.
 

--- a/process-c/deploy/README.md
+++ b/process-c/deploy/README.md
@@ -94,14 +94,38 @@ Hit `Ctrl+C` to stop. Process C exits cleanly on `SIGINT`/`SIGTERM`.
 
 | Method | Path | Purpose |
 |---|---|---|
+| `GET` | `/` | Captive-portal landing page — serves the HTML credential form. |
 | `GET` | `/health` | Liveness + provisioning status (`already_provisioned: bool`). |
-| `POST` | `/provision` | Submit `{ssid, password, user_id}`. Writes `device.json`, returns `202` with the generated `shelf_id`, then fires the WiFi switch in the background. |
+| `POST` | `/provision` | Submit `{ssid, password, user_id}` as **JSON** or **form-encoded**. Writes `device.json`, returns `202` (with JSON body for JSON callers, HTML success page for form callers), then fires the WiFi switch in the background. |
 | `POST` | `/reset` | (Opt-in) Deletes `device.json`. |
+| `GET` | `/generate_204`, `/gen_204` | Android captive-portal probe (returns non-204 to trigger portal). |
+| `GET` | `/hotspot-detect.html`, `/library/test/success.html` | iOS / macOS captive-portal probes. |
+| `GET` | `/ncsi.txt`, `/connecttest.txt` | Windows captive-portal probes. |
 | `OPTIONS` | `*` | CORS preflight. |
 
 CORS is enabled (`Access-Control-Allow-Origin: *`) because the companion
 app calls Process C from a browser context while connected to the Pi's
 hotspot.
+
+### Captive portal vs JSON API — which to use
+
+There are two valid ways to drive provisioning, depending on what your
+client is:
+
+- **Native app / curl / scripts:** `POST /provision` with
+  `Content-Type: application/json`. Returns JSON. This is what was
+  documented in earlier revisions of this PR and remains the supported
+  contract.
+- **Browser, no app installed:** the user opens `http://192.168.4.1/`
+  (or it auto-pops via captive-portal probes once DNS hijacking is in
+  place). The HTML form there `POST`s to `/provision` as either JSON
+  (preferred, via JS) or `application/x-www-form-urlencoded` (no-JS
+  fallback). Either way the same handler runs; the response format
+  matches the request.
+
+The captive-portal probes only do useful work once `nmcli`/`dnsmasq`
+hijacks DNS for the AP — see `orchestration/shelfaware_network_setup.sh`.
+Until then, users on the hotspot must navigate to `192.168.4.1` manually.
 
 ---
 

--- a/process-c/process_c/handlers.py
+++ b/process-c/process_c/handlers.py
@@ -1,4 +1,4 @@
-"""HTTP handlers for the three Process C endpoints.
+"""HTTP handlers for Process C's endpoints.
 
 The handlers are intentionally thin: validation lives in pydantic models,
 state mutation lives in :mod:`process_c.device_state`, and the actual
@@ -8,24 +8,41 @@ WifiBackend.
 
 Endpoints
 ---------
+GET  /
+    Captive-portal landing page. Serves the credential form HTML so the
+    user can provision the shelf from a browser without needing a native
+    app. Same-origin POST to /provision avoids the mixed-content blocking
+    that hits HTTPS web apps trying to talk to http://192.168.4.1.
+
 GET  /health
     Used by the frontend to detect "I'm talking to a Pi in setup mode."
     Always 200 OK; no auth.
 
 POST /provision
-    Body: ``{"ssid", "password", "user_id"}``. On success persists
-    device.json (with a freshly generated shelf_id) and schedules the
-    background WiFi switch. Returns 202 immediately.
+    Body: ``{"ssid", "password", "user_id"}`` as JSON, OR the same fields
+    as ``application/x-www-form-urlencoded`` (so the HTML form works even
+    if JavaScript is blocked). On success persists device.json (with a
+    freshly generated shelf_id) and schedules the background WiFi switch.
+    Returns 202 (JSON) or 303 redirect (form) on success.
 
 POST /reset
     Wipes device.json. Disabled by default — only registered when
     ``cfg.allow_reset_endpoint`` is true. Useful for dev / re-provisioning.
+
+GET  /generate_204, /hotspot-detect.html, /ncsi.txt
+    Captive-portal probes used by Android, iOS, and Windows respectively
+    to detect "is this a real internet connection?". We return responses
+    that *deliberately* fail the probes so the OS pops its captive-portal
+    browser and loads ``/`` automatically. Without these, the user has to
+    manually navigate to http://192.168.4.1.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
+from importlib import resources
 from typing import Any
 
 from aiohttp import web
@@ -37,6 +54,27 @@ from process_c.provisioner import schedule_provision
 from process_c.wifi_backend import WifiBackend
 
 logger = logging.getLogger(__name__)
+
+
+# Loaded once at import time. The HTML is ~5KB and never changes at
+# runtime, so caching it avoids re-reading the file on every request.
+_PROVISION_HTML: str | None = None
+
+
+def _load_provision_html() -> str:
+    """Read the captive-portal HTML once and cache it.
+
+    Uses ``importlib.resources`` so it works whether the package is
+    installed editable, as a wheel, or via a zipapp.
+    """
+    global _PROVISION_HTML
+    if _PROVISION_HTML is None:
+        _PROVISION_HTML = (
+            resources.files("process_c.templates")
+            .joinpath("provision.html")
+            .read_text(encoding="utf-8")
+        )
+    return _PROVISION_HTML
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -61,6 +99,25 @@ class ProvisionRequest(BaseModel):
 # coroutine with a fake Request) and avoids stringly-typed app["wifi"] keys.
 
 
+def make_index_handler(cfg: Config) -> Any:
+    """Captive-portal landing page.
+
+    Always serves the form, even when ``already_provisioned`` is true —
+    the form's POST will then 409 and the JS surfaces a friendly error.
+    Serving the form unconditionally keeps the URL stable so OS captive-
+    portal browsers don't get confused by redirects mid-setup.
+    """
+
+    async def index(request: web.Request) -> web.Response:
+        return web.Response(
+            body=_load_provision_html(),
+            content_type="text/html",
+            charset="utf-8",
+        )
+
+    return index
+
+
 def make_health_handler(cfg: Config) -> Any:
     async def health(request: web.Request) -> web.Response:
         provisioned = device_state.is_provisioned(cfg.device_file_path)
@@ -79,33 +136,33 @@ def make_health_handler(cfg: Config) -> Any:
 
 def make_provision_handler(cfg: Config, wifi: WifiBackend) -> Any:
     async def provision(request: web.Request) -> web.Response:
-        # Refuse if already provisioned — caller must hit /reset first.
-        # Frontend should check /health first, but defend anyway.
+        # Detect whether this came from the HTML form (no JS path) or an
+        # API client. Drives whether errors are HTML/redirects or JSON.
+        wants_html = _client_wants_html(request)
+
         if device_state.is_provisioned(cfg.device_file_path):
-            return _json_response(
-                409,
-                {
-                    "error": "already_provisioned",
-                    "detail": "Device already has a device.json. POST /reset first.",
-                },
+            return _provision_error(
+                wants_html,
+                status=409,
+                code="already_provisioned",
+                detail="Device already has a device.json. POST /reset first.",
             )
 
         try:
-            raw = await request.json()
-        except ValueError:
-            return _json_response(
-                400, {"error": "validation", "detail": "Body must be valid JSON."}
+            raw = await _read_provision_payload(request)
+        except _PayloadError as exc:
+            return _provision_error(
+                wants_html, status=400, code="validation", detail=exc.message
             )
 
         try:
             req = ProvisionRequest.model_validate(raw)
         except ValidationError as exc:
-            return _json_response(
-                400,
-                {
-                    "error": "validation",
-                    "detail": exc.errors(include_url=False, include_input=False),
-                },
+            return _provision_error(
+                wants_html,
+                status=400,
+                code="validation",
+                detail=exc.errors(include_url=False, include_input=False),
             )
 
         # Generate a fresh shelf_id locally so the Pi has a stable identity
@@ -118,12 +175,11 @@ def make_provision_handler(cfg: Config, wifi: WifiBackend) -> Any:
             device_state.write(cfg.device_file_path, state)
         except OSError as exc:
             logger.exception("failed to write device.json")
-            return _json_response(
-                500,
-                {
-                    "error": "persistence",
-                    "detail": f"Could not write device file: {exc}",
-                },
+            return _provision_error(
+                wants_html,
+                status=500,
+                code="persistence",
+                detail=f"Could not write device file: {exc}",
             )
 
         # Spawn the WiFi switch in the background; do NOT await it.
@@ -137,8 +193,17 @@ def make_provision_handler(cfg: Config, wifi: WifiBackend) -> Any:
                 "user_id": req.user_id,
                 "shelf_id": shelf_id,
                 "ssid": req.ssid,
+                "via": "html" if wants_html else "json",
             },
         )
+
+        if wants_html:
+            # No-JS browsers land here — render a tiny success page rather
+            # than a JSON blob the user wouldn't understand.
+            return _html_response(
+                _success_html(shelf_id),
+                status=202,
+            )
 
         return _json_response(
             202,
@@ -160,6 +225,52 @@ def make_reset_handler(cfg: Config) -> Any:
         )
 
     return reset
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Captive-portal probe handlers
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# Each major OS hits a known URL on a known host shortly after joining a
+# new WiFi network to detect "is there real internet here?". The expected
+# upstream responses are:
+#
+#   Android: GET http://connectivitycheck.gstatic.com/generate_204
+#       → empty body, HTTP 204. Anything else => "captive portal".
+#   iOS:     GET http://captive.apple.com/hotspot-detect.html
+#       → body must contain the literal string "Success".
+#       Anything else => "captive portal".
+#   Windows: GET http://www.msftncsi.com/ncsi.txt
+#       → body must be exactly "Microsoft NCSI".
+#       Anything else => "captive portal".
+#
+# When AP-side DNS hijacking redirects these hostnames to the Pi (set up
+# separately in shelfaware_network_setup.sh), the responses below
+# deliberately fail each OS's "I have internet" check, which causes the
+# OS to pop its captive-portal browser pointed at our /.
+#
+# Without DNS hijacking these endpoints are dead code — the OS probes
+# never reach the Pi at all. They're cheap to keep around for the day
+# DNS hijacking lands.
+
+
+async def captive_probe_android(request: web.Request) -> web.Response:
+    """Android probe: expects 204 empty. We return 200 with a body to fail."""
+    return web.Response(text="captive", content_type="text/plain", status=200)
+
+
+async def captive_probe_apple(request: web.Request) -> web.Response:
+    """iOS probe: expects body to contain `Success`. Return something else."""
+    return web.Response(
+        text="<HTML><HEAD></HEAD><BODY>shelfaware</BODY></HTML>",
+        content_type="text/html",
+        status=200,
+    )
+
+
+async def captive_probe_windows(request: web.Request) -> web.Response:
+    """Windows probe: expects exact `Microsoft NCSI`. Return something else."""
+    return web.Response(text="captive", content_type="text/plain", status=200)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -197,3 +308,137 @@ def _cors_response(response: web.StreamResponse) -> web.StreamResponse:
 
 def _json_response(status: int, payload: dict[str, Any]) -> web.Response:
     return web.json_response(payload, status=status)
+
+
+def _html_response(body: str, status: int = 200) -> web.Response:
+    return web.Response(body=body, status=status, content_type="text/html", charset="utf-8")
+
+
+class _PayloadError(Exception):
+    """Raised when the request body can't be parsed into a dict."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+def _client_wants_html(request: web.Request) -> bool:
+    """Decide whether to render HTML/redirect or return JSON.
+
+    Heuristic, in priority order:
+    1. Form-encoded body (Content-Type: application/x-www-form-urlencoded)
+       => definitely a no-JS browser submission, return HTML.
+    2. Accept header explicitly mentions text/html (and not application/json)
+       => browser-driven request without JS, return HTML.
+    3. Otherwise => JSON.
+
+    Native apps and the JS in our own form both POST JSON with
+    ``Accept: */*`` (or unset), which falls into case 3.
+    """
+    content_type = (request.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+    if content_type == "application/x-www-form-urlencoded":
+        return True
+
+    accept = (request.headers.get("Accept") or "").lower()
+    if "application/json" in accept:
+        return False
+    if "text/html" in accept:
+        return True
+    return False
+
+
+async def _read_provision_payload(request: web.Request) -> dict[str, Any]:
+    """Read the body as either JSON or form-encoded into a plain dict.
+
+    Raises :class:`_PayloadError` with a human-readable message if the
+    body isn't parseable. Down-stream pydantic validation handles
+    field-level errors.
+    """
+    content_type = (request.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+
+    if content_type == "application/x-www-form-urlencoded":
+        # aiohttp's .post() returns a MultiDictProxy; flatten to a regular
+        # dict (last value wins for duplicates — same shape pydantic expects).
+        form = await request.post()
+        return {key: form.get(key) for key in form.keys()}
+
+    # Default to JSON. Some browsers may POST with no Content-Type header
+    # at all (rare); JSON parsing will fail clearly in that case.
+    body = await request.read()
+    if not body:
+        raise _PayloadError("Body must be valid JSON.")
+    try:
+        parsed = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise _PayloadError(f"Body must be valid JSON: {exc}") from exc
+
+    if not isinstance(parsed, dict):
+        raise _PayloadError("JSON body must be an object, not a list or scalar.")
+    return parsed
+
+
+def _provision_error(
+    wants_html: bool, *, status: int, code: str, detail: Any
+) -> web.Response:
+    """Render a provisioning error in the format the client expects."""
+    if wants_html:
+        return _html_response(_error_html(status, code, detail), status=status)
+    return _json_response(status, {"error": code, "detail": detail})
+
+
+# Shared style for the no-JS success / error pages. Mirrors the main
+# captive-portal template's light-theme + monospace look so the post-
+# submit experience feels continuous with the form.
+_PAGE_STYLE = (
+    "body{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"
+    "'Liberation Mono','Courier New',monospace;background:#f3f1ee;color:#1f1a17;"
+    "margin:0;min-height:100vh;display:flex;align-items:center;"
+    "justify-content:center;padding:1.5rem;-webkit-font-smoothing:antialiased}"
+    ".box{max-width:440px;width:100%;background:#ffffff;border:1px solid #d9d4ce;"
+    "padding:2rem;border-radius:12px}"
+    "h1{margin:0 0 0.5rem;font-size:1.5rem;font-weight:700;letter-spacing:-0.01em}"
+    "p{margin:0 0 0.85rem;line-height:1.5}"
+    ".muted{color:#6b635c;font-size:0.875rem}"
+    "code{background:#f3f1ee;border:1px solid #d9d4ce;padding:0.6rem 0.75rem;"
+    "border-radius:6px;display:block;margin:0.5rem 0;font-size:0.8rem;"
+    "text-align:left;overflow-wrap:break-word;white-space:pre-wrap}"
+    "a{color:#1f1a17}"
+)
+
+
+def _success_html(shelf_id: str) -> str:
+    """Tiny success page for no-JS browser submissions.
+
+    Inline-styled so it works even with no network. Doesn't try to
+    render the shelf_id prominently — the user doesn't need to see it,
+    the orchestrator and Process B handle the rest.
+    """
+    return (
+        "<!doctype html><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+        "<title>ShelfAware setup</title>"
+        f"<style>{_PAGE_STYLE}</style>"
+        "<div class='box'>"
+        "<h1>Setup accepted</h1>"
+        "<p>Your shelf is now connecting to your home WiFi.</p>"
+        "<p>Reconnect your phone to your home WiFi to finish setup.</p>"
+        f"<p class='muted'>Shelf ID: {shelf_id}</p>"
+        "</div>"
+    )
+
+
+def _error_html(status: int, code: str, detail: Any) -> str:
+    """Tiny error page for no-JS browser submissions."""
+    detail_str = detail if isinstance(detail, str) else json.dumps(detail)
+    return (
+        "<!doctype html><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+        "<title>ShelfAware setup error</title>"
+        f"<style>{_PAGE_STYLE}</style>"
+        "<div class='box'>"
+        f"<h1>Setup failed ({status})</h1>"
+        f"<p class='muted'>{code}</p>"
+        f"<code>{detail_str}</code>"
+        "<p><a href='/'>Try again</a></p>"
+        "</div>"
+    )

--- a/process-c/process_c/main.py
+++ b/process-c/process_c/main.py
@@ -28,8 +28,12 @@ from aiohttp import web
 from process_c import logging_setup
 from process_c.config import Config, ConfigError
 from process_c.handlers import (
+    captive_probe_android,
+    captive_probe_apple,
+    captive_probe_windows,
     cors_middleware,
     make_health_handler,
+    make_index_handler,
     make_provision_handler,
     make_reset_handler,
 )
@@ -87,8 +91,21 @@ def build_app(cfg: Config, wifi: WifiBackend) -> web.Application:
     """Construct the aiohttp Application. Exposed for tests."""
     app = web.Application(middlewares=[cors_middleware])
 
+    # Captive-portal landing page (HTML form). GET / is what OS captive
+    # portal browsers will hit after DNS hijacking redirects them here.
+    app.router.add_get("/", make_index_handler(cfg))
+
     app.router.add_get("/health", make_health_handler(cfg))
     app.router.add_post("/provision", make_provision_handler(cfg, wifi))
+
+    # OS captive-portal probes. Trigger the OS to pop its captive-portal
+    # browser when DNS hijacking is in place. Harmless no-ops otherwise.
+    app.router.add_get("/generate_204", captive_probe_android)  # Android
+    app.router.add_get("/gen_204", captive_probe_android)  # Android (older path)
+    app.router.add_get("/hotspot-detect.html", captive_probe_apple)  # iOS / macOS
+    app.router.add_get("/library/test/success.html", captive_probe_apple)  # iOS variant
+    app.router.add_get("/ncsi.txt", captive_probe_windows)  # Windows
+    app.router.add_get("/connecttest.txt", captive_probe_windows)  # Windows 10+
 
     if cfg.allow_reset_endpoint:
         app.router.add_post("/reset", make_reset_handler(cfg))

--- a/process-c/process_c/templates/__init__.py
+++ b/process-c/process_c/templates/__init__.py
@@ -1,0 +1,8 @@
+"""Static templates served by Process C.
+
+We package this directory so ``importlib.resources`` can locate the HTML
+files at runtime regardless of how the package was installed (editable
+checkout, wheel, zipapp, etc.). Without an ``__init__.py`` the directory
+is data, not a package, and resource lookup gets fiddly across Python
+versions.
+"""

--- a/process-c/process_c/templates/provision.html
+++ b/process-c/process_c/templates/provision.html
@@ -1,0 +1,232 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ShelfAware setup</title>
+  <style>
+    /* Self-contained CSS — captive-portal browsers often block external
+       requests, and we have no internet anyway. Keep everything inline.
+       Visual language matches the main ShelfAware web app (light theme,
+       monospace font, soft borders, dark primary button). */
+    :root {
+      --bg: #f3f1ee;
+      --card: #ffffff;
+      --text: #1f1a17;
+      --muted: #6b635c;
+      --border: #d9d4ce;
+      --border-strong: #1f1a17;
+      --primary: #2a2320;
+      --primary-hover: #161210;
+      --error: #b91c1c;
+      --error-bg: #fef2f2;
+      --success: #166534;
+      --success-bg: #f0fdf4;
+    }
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0;
+      padding: 0;
+      min-height: 100%;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+                   "Liberation Mono", "Courier New", monospace;
+      background: var(--bg);
+      color: var(--text);
+      -webkit-font-smoothing: antialiased;
+    }
+    .wrap {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+    }
+    .card {
+      width: 100%;
+      max-width: 440px;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 2rem 2rem 1.75rem;
+    }
+    h1 {
+      margin: 0 0 0.5rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+    }
+    p.subtitle {
+      margin: 0 0 1.75rem;
+      color: var(--muted);
+      font-size: 1rem;
+    }
+    label {
+      display: block;
+      margin-bottom: 1.1rem;
+      font-size: 0.95rem;
+      font-weight: 500;
+      color: var(--text);
+    }
+    input {
+      display: block;
+      width: 100%;
+      margin-top: 0.4rem;
+      padding: 0.7rem 0.85rem;
+      font-size: 1rem;
+      font-family: inherit;
+      color: var(--text);
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      transition: border-color 0.15s;
+    }
+    input:focus {
+      outline: none;
+      border-color: var(--border-strong);
+    }
+    input::placeholder { color: var(--muted); opacity: 0.7; }
+    button {
+      width: 100%;
+      margin-top: 0.5rem;
+      padding: 0.85rem;
+      font-size: 1rem;
+      font-family: inherit;
+      font-weight: 600;
+      color: #ffffff;
+      background: var(--primary);
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    button:hover:not(:disabled) { background: var(--primary-hover); }
+    button:disabled { opacity: 0.55; cursor: not-allowed; }
+    #status {
+      margin-top: 1.25rem;
+      padding: 0.85rem 1rem;
+      border-radius: 8px;
+      font-size: 0.9rem;
+      line-height: 1.45;
+      display: none;
+    }
+    #status.show { display: block; }
+    #status.error {
+      background: var(--error-bg);
+      border: 1px solid var(--error);
+      color: var(--error);
+    }
+    #status.success {
+      background: var(--success-bg);
+      border: 1px solid var(--success);
+      color: var(--success);
+    }
+    .hint {
+      margin: 1.25rem 0 0;
+      font-size: 0.825rem;
+      color: var(--muted);
+      text-align: center;
+      line-height: 1.5;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="card">
+      <h1>ShelfAware</h1>
+      <p class="subtitle">Connect your shelf to WiFi</p>
+
+      <!-- Native form submission works without JS (form-encoded). The JS
+           below upgrades it to fetch() for a smoother UX, but the page
+           still functions if scripts are blocked. -->
+      <form id="provision-form" method="POST" action="/provision">
+        <label>
+          WiFi network (SSID)
+          <input type="text" name="ssid" required maxlength="32"
+                 autocomplete="off" autocapitalize="off">
+        </label>
+        <label>
+          WiFi password
+          <input type="password" name="password" required minlength="8" maxlength="63">
+        </label>
+        <label>
+          Account ID
+          <input type="text" name="user_id" required
+                 autocomplete="off" autocapitalize="off"
+                 placeholder="paste from the ShelfAware app">
+        </label>
+        <button type="submit" id="submit-btn">Connect</button>
+      </form>
+
+      <div id="status"></div>
+
+      <p class="hint">
+        After tapping Connect, your phone will lose this WiFi network.<br>
+        Reconnect to your home WiFi to finish setup.
+      </p>
+    </div>
+  </div>
+
+  <script>
+    // Progressive enhancement: if JS is available, POST as JSON so we get
+    // structured error responses. If JS is blocked, the form submits as
+    // application/x-www-form-urlencoded — which the /provision handler
+    // also accepts. Either way, the user can finish provisioning.
+    (function () {
+      var form = document.getElementById("provision-form");
+      var status = document.getElementById("status");
+      var btn = document.getElementById("submit-btn");
+
+      function showStatus(kind, message) {
+        status.className = "show " + kind;
+        status.textContent = message;
+      }
+
+      form.addEventListener("submit", async function (event) {
+        event.preventDefault();
+        btn.disabled = true;
+        showStatus("", "Sending...");
+
+        var data = {
+          ssid: form.ssid.value,
+          password: form.password.value,
+          user_id: form.user_id.value,
+        };
+
+        try {
+          var res = await fetch("/provision", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+          });
+          var body = await res.json();
+
+          if (res.status === 202) {
+            showStatus(
+              "success",
+              "Accepted. Reconnect your phone to your home WiFi to finish setup."
+            );
+            form.style.display = "none";
+          } else if (res.status === 409) {
+            showStatus(
+              "error",
+              "This shelf is already set up. Use the reset flow if you want to change it."
+            );
+          } else {
+            var detail = body && body.detail
+              ? (typeof body.detail === "string" ? body.detail : JSON.stringify(body.detail))
+              : "Setup failed. Please try again.";
+            showStatus("error", "Error: " + detail);
+            btn.disabled = false;
+          }
+        } catch (err) {
+          showStatus(
+            "error",
+            "Could not reach the shelf. Make sure you're still connected to ShelfAware_Setup."
+          );
+          btn.disabled = false;
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/process-c/pyproject.toml
+++ b/process-c/pyproject.toml
@@ -30,6 +30,13 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["process_c"]
 
+# Include captive-portal HTML templates. importlib.resources finds them
+# at runtime via the process_c.templates subpackage (its __init__.py
+# makes hatchling track the directory; this stanza ensures the .html
+# files travel along with the .py).
+[tool.hatch.build.targets.wheel.force-include]
+"process_c/templates/provision.html" = "process_c/templates/provision.html"
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/process-c/tests/test_captive_portal.py
+++ b/process-c/tests/test_captive_portal.py
@@ -1,0 +1,262 @@
+"""Tests for captive-portal additions: GET /, OS probes, form-encoded POST."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from aiohttp.test_utils import TestClient, TestServer
+
+from process_c import device_state
+from process_c.config import Config
+from process_c.main import build_app
+from process_c.wifi_backend import ConnectResult, FakeWifiBackend
+
+
+def _cfg(device_path: Path, *, allow_reset: bool = False) -> Config:
+    return Config(
+        bind_host="127.0.0.1",
+        bind_port=0,
+        device_file_path=str(device_path),
+        allow_reset_endpoint=allow_reset,
+        log_level="DEBUG",
+        dev_mode=True,
+    )
+
+
+@pytest_asyncio.fixture
+async def make_client():
+    clients: list[TestClient] = []
+
+    async def factory(cfg: Config, wifi: FakeWifiBackend) -> TestClient:
+        app = build_app(cfg, wifi)
+        client = TestClient(TestServer(app))
+        await client.start_server()
+        clients.append(client)
+        return client
+
+    yield factory
+
+    for c in clients:
+        await c.close()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# GET / — captive-portal landing page
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestIndex:
+    async def test_serves_html_with_form(self, tmp_path: Path, make_client) -> None:
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.get("/")
+        assert resp.status == 200
+        assert "text/html" in resp.headers["Content-Type"]
+
+        body = await resp.text()
+        # Smoke check the form is present and points where we expect.
+        assert '<form' in body
+        assert 'action="/provision"' in body
+        assert 'name="ssid"' in body
+        assert 'name="password"' in body
+        assert 'name="user_id"' in body
+
+    async def test_works_even_when_already_provisioned(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        # Form should still render — the POST handler is what enforces
+        # the 409. Keeping the URL stable matters for captive-portal UX.
+        device_path = tmp_path / "device.json"
+        device_state.write(device_path, device_state.make_state("u", "s"))
+
+        cfg = _cfg(device_path)
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.get("/")
+        assert resp.status == 200
+        body = await resp.text()
+        assert '<form' in body
+
+    async def test_template_is_cached_across_requests(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        # Simple "doesn't blow up under repeated requests" smoke check —
+        # the template is read from disk once via importlib.resources and
+        # cached in a module-global.
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        for _ in range(5):
+            resp = await client.get("/")
+            assert resp.status == 200
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Captive-portal probe endpoints
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestCaptiveProbes:
+    """The probes deliberately fail each OS's `is there internet?` check
+    so the OS pops its captive-portal browser. We assert they return
+    bodies/codes that won't be mistaken for "real internet"."""
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/generate_204", "/gen_204"],
+    )
+    async def test_android_probe_is_not_204_empty(
+        self, tmp_path: Path, make_client, path: str
+    ) -> None:
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.get(path)
+        # Real internet returns 204 with empty body. We MUST not.
+        assert resp.status != 204
+        body = await resp.read()
+        assert body, f"Android probe at {path} returned empty body — won't trigger portal"
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/hotspot-detect.html", "/library/test/success.html"],
+    )
+    async def test_apple_probe_does_not_contain_success(
+        self, tmp_path: Path, make_client, path: str
+    ) -> None:
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.get(path)
+        assert resp.status == 200
+        body = await resp.text()
+        # iOS treats body containing literal "Success" as "internet works".
+        assert "Success" not in body, (
+            f"Apple probe at {path} contains 'Success' — iOS would skip captive portal"
+        )
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/ncsi.txt", "/connecttest.txt"],
+    )
+    async def test_windows_probe_is_not_microsoft_ncsi(
+        self, tmp_path: Path, make_client, path: str
+    ) -> None:
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.get(path)
+        assert resp.status == 200
+        body = await resp.text()
+        assert body.strip() != "Microsoft NCSI", (
+            f"Windows probe at {path} returned exact upstream string — no portal popup"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Form-encoded POST /provision (no-JS browser fallback)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestProvisionFormEncoded:
+    async def test_form_post_returns_html_success_page(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        device_path = tmp_path / "device.json"
+        cfg = _cfg(device_path)
+        wifi = FakeWifiBackend(next_result=ConnectResult.SUCCESS)
+        client = await make_client(cfg, wifi)
+
+        resp = await client.post(
+            "/provision",
+            data={
+                "ssid": "MyWifi",
+                "password": "hunter2-strong",
+                "user_id": "user-uuid-1",
+            },
+        )
+        # Form submission returns HTML, not JSON.
+        assert resp.status == 202
+        assert "text/html" in resp.headers["Content-Type"]
+
+        body = await resp.text()
+        assert "Setup accepted" in body or "accepted" in body.lower()
+
+        # device.json was still written (state is the same regardless of
+        # how the request came in).
+        loaded = device_state.read(device_path)
+        assert loaded is not None
+        assert loaded.user_id == "user-uuid-1"
+
+    async def test_form_post_validation_error_returns_html(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.post(
+            "/provision",
+            data={"ssid": "x", "password": "short", "user_id": "u"},
+        )
+        # Validation failure for a form submission still renders HTML.
+        assert resp.status == 400
+        assert "text/html" in resp.headers["Content-Type"]
+        body = await resp.text()
+        assert "Setup failed" in body or "error" in body.lower()
+
+    async def test_form_post_already_provisioned_returns_html(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        device_path = tmp_path / "device.json"
+        device_state.write(device_path, device_state.make_state("u", "s"))
+
+        cfg = _cfg(device_path)
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.post(
+            "/provision",
+            data={"ssid": "x", "password": "12345678", "user_id": "u2"},
+        )
+        assert resp.status == 409
+        assert "text/html" in resp.headers["Content-Type"]
+
+    async def test_json_post_still_returns_json(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        # Regression: adding form-encoded support shouldn't break the
+        # existing JSON contract that Emmanuel and curl/native apps use.
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.post(
+            "/provision",
+            json={
+                "ssid": "x",
+                "password": "12345678",
+                "user_id": "u",
+            },
+        )
+        assert resp.status == 202
+        assert "application/json" in resp.headers["Content-Type"]
+        body = await resp.json()
+        assert body["status"] == "accepted"
+
+    async def test_explicit_accept_html_returns_html_even_for_json_body(
+        self, tmp_path: Path, make_client
+    ) -> None:
+        # Edge case: a browser JS app that explicitly says Accept: text/html
+        # (unusual). We honour the header.
+        cfg = _cfg(tmp_path / "device.json")
+        client = await make_client(cfg, FakeWifiBackend())
+
+        resp = await client.post(
+            "/provision",
+            json={"ssid": "x", "password": "12345678", "user_id": "u"},
+            headers={"Accept": "text/html"},
+        )
+        assert resp.status == 202
+        assert "text/html" in resp.headers["Content-Type"]


### PR DESCRIPTION
Process C now serves an HTML credential form at GET / so users can provision the shelf from a browser without needing a native app — side-stepping the mixed-content blocking that hits HTTPS web apps trying to call http://192.168.4.1. POST /provision was extended to accept application/x-www-form-urlencoded bodies in addition to JSON, so the form works even when JavaScript is blocked.

Also wired up the OS captive-portal probes (Android /generate_204, iOS /hotspot-detect.html, Windows /ncsi.txt + variants) so that, once AP-side DNS hijacking lands in shelfaware_network_setup.sh, the OS will auto-pop its captive-portal browser pointed at /. Probes return deliberately-not-internet responses to fail each OS's connectivity check. Until DNS hijacking ships, users on the hotspot must navigate to 192.168.4.1 manually — these endpoints are dead code in the meantime, but cheap to keep ready.

Visual language matches the main ShelfAware web app (light theme, monospace font, dark primary button, soft borders).

Implementation
- New process_c/templates/provision.html with self-contained CSS/JS (no external requests — the hotspot has no internet).
- Progressive enhancement: form posts as JSON when JS is available (better error UX), as form-encoded otherwise.
- handlers.py negotiates response format from Content-Type/Accept: HTML form callers get HTML success/error pages, JSON callers get the existing JSON contract Emmanuel & curl/native apps already use.
- Captive-portal probes return non-{204, "Success", "Microsoft NCSI"} responses so each OS classifies the network as captive.
- pyproject.toml force-includes the HTML in the wheel via hatchling.

Tests
- 14 new tests in tests/test_captive_portal.py (HTML form rendering, probe payload correctness for all three OSes, form-encoded POST happy/error paths, JSON regression check, Accept-header negotiation).
- All 85 Process C tests pass; all 142 Process B tests still pass.
- Lint clean.

Out of scope
- AP-side DNS hijacking (dnsmasq + iptables) to actually trigger the captive-portal popup — that's an orchestration/ change for later.
- Claim codes (currently the form still asks the user to paste their account UUID; will be replaced when the backend mints short codes).